### PR TITLE
[AMT-34] 빌드 에러 및 미리보기 서버 동작 오류 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dist-ssr
 *.sw?
 
 .bedrock
+/dist/*

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "bedrock dev",
     "build": "bedrock build",
     "lint": "eslint .",
-    "preview": "vite preview",
+    "preview": "vite preview --outDir dist/web",
     "deploy": "ait deploy"
   },
   "dependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { RouterProvider } from 'react-router-dom';
 import router from './routes';
 import { Suspense } from 'react';
-import Layout from './components/layout/Layout';
+import LayoutWrapper from './components/layout/LayoutWrapper';
 
 function App() {
   return (
@@ -9,9 +9,9 @@ function App() {
       {/* 렌더링 되기 전 로딩될 UI 제공 */}
       <Suspense
         fallback={
-          <Layout>
+          <LayoutWrapper>
             <div>로딩 중...</div>
-          </Layout>
+          </LayoutWrapper>
         }
       >
         {/* @ts-expect-error Temporarily disabled error */}

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,11 +1,10 @@
 import { Outlet } from 'react-router-dom';
+import LayoutWrapper from './LayoutWrapper';
 
 export default function Layout() {
   return (
-    <section className='bg-black flex justify-center min-h-[100dvh]'>
-      <section className='bg-background-light dark:bg-gray7 safe-container w-full max-w-[var(--max-size-mobile)]'>
-        <Outlet />
-      </section>
-    </section>
+    <LayoutWrapper>
+      <Outlet />
+    </LayoutWrapper>
   );
 }

--- a/src/components/layout/LayoutWrapper.tsx
+++ b/src/components/layout/LayoutWrapper.tsx
@@ -1,0 +1,14 @@
+import type React from 'react';
+
+type LayoutWrapperProps = {
+  children: React.ReactNode;
+};
+export default function LayoutWrapper({ children }: LayoutWrapperProps) {
+  return (
+    <section className='bg-black flex justify-center min-h-[100dvh]'>
+      <section className='bg-background-light dark:bg-gray7 safe-container w-full max-w-[var(--max-size-mobile)]'>
+        {children}
+      </section>
+    </section>
+  );
+}


### PR DESCRIPTION
## PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [x] 파일 혹은 폴더 삭제

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세
#### LayoutWrapper 추가
- 기존 Layout 컴포넌트는 react-router의 `<Outlet />`을 감싸는 구조로, 라우터 내부에서만 사용 가능했습니다.
- 라우터 외부(ex. Suspense fallback 등)에서도 동일한 레이아웃 구조를 사용할 수 있도록 `LayoutWrapper`를 별도 분리했습니다.

#### preview 서버 동작 오류 수정
- 문제 원인
  - 기본적으로 vite preview는 `dist/index.html`을 기준으로 미리보기 서버를 실행합니다.
  - 하지만 Toss 기반의 bedrock 빌드는 결과물을 `dist/web/` 하위에 생성하기 때문에, preview 서버가 `index.html`을 찾지 못하고 실패했습니다.
- 해결 방법
  - preview 명령어를 수정하여 `dist/web`을 루트로 미리보기 서버가 실행되도록 설정했습니다.


