### PR TITLE
[AMT-45] 해설 상세 조회 API 연동

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { RouterProvider } from 'react-router-dom';
 import router from './routes';
 import { Suspense } from 'react';
 import LayoutWrapper from './components/layout/LayoutWrapper';
+import Loading from './components/ui/Loading';
 
 function App() {
   return (
@@ -10,7 +11,7 @@ function App() {
       <Suspense
         fallback={
           <LayoutWrapper>
-            <div>로딩 중...</div>
+            <Loading />
           </LayoutWrapper>
         }
       >

--- a/src/components/ui/Loading.tsx
+++ b/src/components/ui/Loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div>로딩 중...</div>;
+}

--- a/src/features/keywords/components/KeywordList.tsx
+++ b/src/features/keywords/components/KeywordList.tsx
@@ -6,29 +6,26 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import type { Concept } from '@/types/concept';
 import { DialogClose, DialogTrigger } from '@radix-ui/react-dialog';
 
 type ConceptListProps = {
-  concepts: string[];
+  concepts: Omit<Concept, 'description'>[];
 };
 
 export default function KeywordList({ concepts }: ConceptListProps) {
   return (
     <ul className='flex items-center flex-wrap gap-x-2 gap-y-0.5'>
       {concepts.map((concept) => (
-        <Dialog key={concept}>
+        <Dialog key={concept.id}>
           <DialogTrigger asChild>
-            <li className='text-primary cursor-pointer'>#{concept}</li>
+            <li className='text-primary cursor-pointer'>#{concept.name}</li>
           </DialogTrigger>
           <DialogContent className='flex flex-col items-center gap-6'>
             <DialogHeader>
-              <DialogTitle className='title-sm'># {concept}</DialogTitle>
+              <DialogTitle className='title-sm'># {concept.name}</DialogTitle>
             </DialogHeader>
-            <p className='whitespace-pre-wrap body-sm'>
-              {
-                '설명설명설명\n설명설명설명설명설명설명설명설명설명\n설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명\n설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명'
-              }
-            </p>
+            <p className='whitespace-pre-wrap body-sm'>description</p>
             <DialogFooter>
               <DialogClose asChild>
                 <Button size='sm'>닫기</Button>

--- a/src/features/problems/api/get-problem-detail.ts
+++ b/src/features/problems/api/get-problem-detail.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+import { httpClient } from '@/lib/api-client';
+import { type Problem } from '@/types/problem';
+
+const getProblemDetail = async (id: string) => {
+  const res = await httpClient.get<Problem>(`/problem?problemId=${id}`);
+  return res.data;
+};
+
+export const useProblemDetail = (id: string) => {
+  return useQuery({
+    queryKey: ['problemDetail', id],
+    queryFn: () => getProblemDetail(id),
+  });
+};

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -18,7 +18,7 @@ httpClient.interceptors.request.use(authRequestInterceptor);
 
 httpClient.interceptors.response.use(
   (response) => {
-    return response.data;
+    return response;
   },
   (error) => {
     if (error.response?.status === 401) {

--- a/src/pages/ProblemDetailPage.tsx
+++ b/src/pages/ProblemDetailPage.tsx
@@ -1,3 +1,7 @@
+import axios from 'axios';
+import { useParams } from 'react-router-dom';
+import ServerErrorPage from '@/pages/ServerErrorPage';
+import NotFoundPage from '@/pages/NotFoundPage';
 import SubHeader from '@/components/layout/SubHeader';
 import KeywordList from '@/features/keywords/components/KeywordList';
 import CardWrapper from '@/features/problems/components/CardWrapper';
@@ -5,42 +9,38 @@ import DetailFooter from '@/features/problems/detail/DetailFooter';
 import DetailSection from '@/features/problems/detail/DetailSection';
 import ImageSection from '@/features/problems/detail/ImageSection';
 import Title from '@/features/problems/components/Title';
+import Loading from '@/components/ui/Loading';
 import { formatDetailDate } from '@/utils/date';
+import { useProblemDetail } from '@/features/problems/api/get-problem-detail';
+import { handleApiError } from '@/utils/handle-api-error';
 
-const data = {
-  id: 1,
-  name: '*포포즈(four fours)게임은 숫자 4 4개를 가지고 수를 맞추는 게임으로, 영국에서 만들어져 미국에서 유행한 수학 퍼즐게임입니다. 1단원에서 공부한 내용을 바탕으로 퍼즐을 풀어봅시다.\n*숫자 4 4개와 사칙계산 기호를 사용하여 숫자를 만들어봅시다.',
-  image: '/images/mock2.png',
-  categories: [
-    '포포즈 게임',
-    '자연수',
-    '혼합 계산',
-    '괄호',
-    '사칙연산',
-    '해시태그2',
-    '해시태그3',
-    '해시태그4',
-    '해시태그5',
-  ],
-  favorite: true,
-  answer:
-    'STEP 1. 어쩌고 저쩌고\n어쩌고저쩌고어쩌고저쩌고어쩌고저쩌고어쩌고어쩌고저쩌고어쩌고어쩌고저쩌고어쩌고어쩌고저쩌고어쩌고어쩌고저쩌고어쩌고어쩌고저쩌고어쩌고어쩌고저쩌고어쩌고어쩌고저쩌고어쩌고어쩌고저쩌고어쩌고\n\nSTEP 2. 어쩌고 저쩌고\n어쩌고저쩌고어쩌고어쩌고저쩌고어쩌',
-  created_at: '2025-07-02 10:20:12.123 +0000',
-  updated_at: '2025-07-02 10:20:12.123 +0000',
-};
-
+//ImageSection 컴포넌트의 url prop : api 수정 완료 후 data.imageUrl로 업데이트할 예정
 export default function ProblemDetailPage() {
+  const { _id } = useParams();
+
+  const { data, isPending, isError, error } = useProblemDetail(_id!);
+
+  if (isError) {
+    handleApiError(error);
+
+    const status = axios.isAxiosError(error) ? error.response?.status : null;
+    if (status === 404) return <NotFoundPage />;
+    return <ServerErrorPage />;
+  }
+
+  if (isPending) return <Loading />;
+
   return (
     <section className='w-full h-full flex flex-col'>
       <SubHeader type='back' title='해설 보기' />
       <main className='flex-1 flex flex-col gap-4 py-3 px-6'>
         <p className='text-right label text-gray5 dark:text-gray2'>
-          {formatDetailDate(data.created_at)}
+          {formatDetailDate(data.createdAt)}
         </p>
-        <ImageSection url={data.image} alt={data.name} />
+        <ImageSection url={'/images/mock3.png'} alt={String(data.id)} />
         <DetailSection>
           <Title size='lg'>문제</Title>
-          <CardWrapper>{data.name}</CardWrapper>
+          <CardWrapper>{data.ocrResult}</CardWrapper>
         </DetailSection>
         <DetailSection>
           <Title
@@ -50,12 +50,12 @@ export default function ProblemDetailPage() {
             핵심 개념
           </Title>
           <CardWrapper>
-            <KeywordList concepts={data.categories} />
+            <KeywordList concepts={data.concepts} />
           </CardWrapper>
         </DetailSection>
         <DetailSection>
           <Title size='lg'>이렇게 설명해볼까요?</Title>
-          <CardWrapper>{data.answer}</CardWrapper>
+          <CardWrapper>{data.llmResult}</CardWrapper>
         </DetailSection>
       </main>
       <DetailFooter isFavorite={data.favorite} />

--- a/src/pages/ProblemDetailPage.tsx
+++ b/src/pages/ProblemDetailPage.tsx
@@ -14,7 +14,6 @@ import { formatDetailDate } from '@/utils/date';
 import { useProblemDetail } from '@/features/problems/api/get-problem-detail';
 import { handleApiError } from '@/utils/handle-api-error';
 
-//ImageSection 컴포넌트의 url prop : api 수정 완료 후 data.imageUrl로 업데이트할 예정
 export default function ProblemDetailPage() {
   const { _id } = useParams();
 
@@ -37,7 +36,7 @@ export default function ProblemDetailPage() {
         <p className='text-right label text-gray5 dark:text-gray2'>
           {formatDetailDate(data.createdAt)}
         </p>
-        <ImageSection url={'/images/mock3.png'} alt={String(data.id)} />
+        <ImageSection url={data.imageUrl} alt={String(data.id)} />
         <DetailSection>
           <Title size='lg'>문제</Title>
           <CardWrapper>{data.ocrResult}</CardWrapper>

--- a/src/types/concept.ts
+++ b/src/types/concept.ts
@@ -1,0 +1,5 @@
+export type Concept = {
+  id: number;
+  name: string;
+  description: string;
+};

--- a/src/types/problem.ts
+++ b/src/types/problem.ts
@@ -2,7 +2,7 @@ import type { Concept } from './concept';
 
 export type Problem = {
   id: number;
-  imageId: number; // 추후 url로 변경될 예정
+  imageUrl: string;
   concepts: Omit<Concept, 'description'>[];
   favorite: boolean;
   ocrResult: string;

--- a/src/types/problem.ts
+++ b/src/types/problem.ts
@@ -1,0 +1,24 @@
+import type { Concept } from './concept';
+
+export type Problem = {
+  id: number;
+  imageId: number; // 추후 url로 변경될 예정
+  concepts: Omit<Concept, 'description'>[];
+  favorite: boolean;
+  ocrResult: string;
+  llmResult: string;
+  createdAt: string;
+};
+
+export type GetProblemListResponse = {
+  data: Problem[];
+  pagination: {
+    limit: number;
+    hasNextPage: boolean;
+    nextCursor: string;
+  };
+  links: {
+    self: string;
+    next: string;
+  };
+};


### PR DESCRIPTION
## PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세
#### 로딩 컴포넌트 분리
- 기존에 하드코딩되어 있던 로딩 UI를 분리하여 Loading 컴포넌트로 작성했습니다. (스타일링은 미적용 상태)
- 위치: /src/components/ui/Loading.tsx

#### 타입 정의 추가
- API 응답 타입을 정의하기 위해 /src/types 폴더 내에 다음 파일을 추가했습니다:
  - problem.ts: 문제 상세 타입 정의
  - concept.ts: 핵심 개념(키워드) 타입 정의

#### 데이터 fetch 함수 및 커스텀 훅 작성
- 문제 상세 데이터 요청을 위한 API 함수 및 React Query 훅을 추가했습니다.
  - API 함수: getProblemDetail (axios 기반)
  - 커스텀 훅: useProblemDetail (useQuery 사용)
  - 위치: src/features/problems/api/get-problem-detail.ts

#### 문제 상세 페이지 API 연동
- 상세 페이지에서 API로부터 받은 데이터를 사용하도록 연동했습니다.
- ~~참고 : 현재 서버에서 이미지 URL이 아닌 ID만 받아오고 있어 이미지 항목을 제외한 나머지 항목들만 실제 데이터를 기반으로 렌더링됩니다.~~
  - (수정 완)

#### 에러 처리 개선
- 400(bad request)등 401/404 외 클라이언트 에러 발생 시 빈 화면만 보여지던 문제를 수정했습니다.
  - 기존에는 401/404/500대 에러만 처리했으나 500대 에러 이외의 예외 상황도 ServerErrorPage를 보여주도록 처리했습니다.

#### Axios response 인터셉터 수정
- react-query가 반환 데이터를 인식하지 못하는 문제가 발생하여 httpClient에서 response.data만 반환하던 부분을 전체 response 객체를 반환하도록 수정했습니다. 