### PR TITLE
[AMT-46] 해설 목록 페이지 API 연동

### DIFF
--- a/src/features/problems/api/get-problem-list.ts
+++ b/src/features/problems/api/get-problem-list.ts
@@ -18,6 +18,8 @@ export const useProblemList = () => {
     queryFn: getProblemList,
     initialPageParam: '',
     getNextPageParam: (lastPage) =>
-      lastPage.pagination.hasNextPage ? lastPage.pagination.nextCursor : '',
+      lastPage.pagination.hasNextPage
+        ? lastPage.pagination.nextCursor
+        : undefined,
   });
 };

--- a/src/features/problems/api/get-problem-list.ts
+++ b/src/features/problems/api/get-problem-list.ts
@@ -1,0 +1,23 @@
+import { httpClient } from '@/lib/api-client';
+import {
+  type CursorPaginationParams,
+  type GetProblemListResponse,
+} from '@/types/problem';
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+const getProblemList = async ({ pageParam }: CursorPaginationParams) => {
+  const res = await httpClient.get<GetProblemListResponse>(
+    `/problem/list?limit=10&memberId=1${pageParam ? `&after_cursor=${pageParam}` : ''}`
+  );
+  return res.data;
+};
+
+export const useProblemList = () => {
+  return useInfiniteQuery({
+    queryKey: ['problemList'],
+    queryFn: getProblemList,
+    initialPageParam: '',
+    getNextPageParam: (lastPage) =>
+      lastPage.pagination.hasNextPage ? lastPage.pagination.nextCursor : '',
+  });
+};

--- a/src/features/problems/hooks/useInfiniteScroll.ts
+++ b/src/features/problems/hooks/useInfiniteScroll.ts
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+
+type InfiniteScrollProps = {
+  targetRef: React.RefObject<HTMLElement | null>;
+  onIntersect: () => void;
+  enabled: boolean;
+  threshold?: number;
+};
+
+export const useInfiniteScroll = ({
+  targetRef,
+  onIntersect,
+  enabled,
+  threshold = 1,
+}: InfiniteScrollProps) => {
+  useEffect(() => {
+    if (!enabled || !targetRef.current) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          onIntersect();
+        }
+      },
+      { threshold }
+    );
+
+    observer.observe(targetRef.current);
+
+    return () => observer.disconnect();
+  }, [enabled, targetRef, onIntersect, threshold]);
+};

--- a/src/features/problems/list/GridView.tsx
+++ b/src/features/problems/list/GridView.tsx
@@ -2,17 +2,10 @@ import { Link } from 'react-router-dom';
 import CardWrapper from '../components/CardWrapper';
 import { Bookmark } from 'lucide-react';
 import { formatListDate } from '@/utils/date';
+import type { Problem } from '@/types/problem';
 
 type GridViewProps = {
-  items: {
-    id: number;
-    name: string;
-    image: string;
-    categories: string[];
-    favorite: boolean;
-    created_at: string;
-    updated_at: string;
-  }[]; // 추후 type으로 정의할 예정
+  items: Problem[];
 };
 
 export default function GridView({ items }: GridViewProps) {
@@ -41,11 +34,11 @@ export default function GridView({ items }: GridViewProps) {
               </button>
               <div className='flex justify-end'>
                 <p className='label text-gray5 dark:text-gray2 pt-4 pr-4'>
-                  {formatListDate(item.created_at)}
+                  {formatListDate(item.createdAt)}
                 </p>
               </div>
               <img
-                src={item.image}
+                src={item.imageUrl}
                 alt={Image.name}
                 className='border-t border-gray1 dark:border-gray4 flex-1 object-contain h-full w-full'
               />

--- a/src/features/problems/list/ListSection.tsx
+++ b/src/features/problems/list/ListSection.tsx
@@ -1,28 +1,43 @@
 import { useSearchParams } from 'react-router-dom';
-import { problems } from '../mock/dummy';
 import Empty from './Empty';
 import GridView from './GridView';
 import ListView from './ListView';
+import { useProblemList } from '../api/get-problem-list';
+import { useRef } from 'react';
+import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
+import Loading from '@/components/ui/Loading';
 
 export default function ListSection() {
   const [params] = useSearchParams();
 
-  // API 연동 시 사용
+  // 즐겨찾기, 검색 조회 API 연동 시 사용
   //const q = params.get('q') ?? '';
   //const favorite = params.get('favorite') === 'true';
   const view = (params.get('view') as 'list' | 'grid') ?? 'list';
 
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPending } =
+    useProblemList();
+
+  const problems = data?.pages.flatMap((page) => page.data) ?? [];
+  const targetRef = useRef<HTMLDivElement | null>(null);
+
+  useInfiniteScroll({
+    targetRef,
+    onIntersect: fetchNextPage,
+    enabled: hasNextPage && !isFetchingNextPage,
+  });
+
+  if (isPending) return <Loading />;
   if (problems.length === 0) {
     return <Empty description='하단의 버튼을 눌러 문제를 등록해보세요' />;
   }
 
+  const ViewComponent = view === 'list' ? ListView : GridView;
   return (
     <section className='w-full'>
-      {view === 'list' ? (
-        <ListView items={problems} />
-      ) : (
-        <GridView items={problems} />
-      )}
+      <ViewComponent items={problems} />
+      {isFetchingNextPage && <Loading />}
+      <div ref={targetRef} className='h-[1px]' />
     </section>
   );
 }

--- a/src/features/problems/list/ListView.tsx
+++ b/src/features/problems/list/ListView.tsx
@@ -4,17 +4,10 @@ import Title from '../components/Title';
 import { Bookmark } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import type React from 'react';
+import type { Problem } from '@/types/problem';
 
 type ListViewProps = {
-  items: {
-    id: number;
-    name: string;
-    image: string;
-    categories: string[];
-    favorite: boolean;
-    created_at: string;
-    updated_at: string;
-  }[];
+  items: Problem[];
 };
 
 export default function ListView({ items }: ListViewProps) {
@@ -35,16 +28,16 @@ export default function ListView({ items }: ListViewProps) {
                 fill={item.favorite ? 'currentColor' : 'none'}
                 onClick={handleToggle}
               />
-              <Title size='md'>{item.name}</Title>
+              <Title size='md'>{item.ocrResult}</Title>
               <p className='body-sm text-gray5 dark:text-gray2 overflow-hidden text-ellipsis whitespace-nowrap'>
-                {item.categories.map((category) => (
-                  <span key={category} className='ml-1'>
-                    #{category}
+                {item.concepts.map((concept) => (
+                  <span key={concept.id} className='ml-1'>
+                    #{concept.name}
                   </span>
                 ))}
               </p>
               <p className='label text-gray5 dark:text-gray2'>
-                {formatListDate(item.created_at)}
+                {formatListDate(item.createdAt)}
               </p>
             </div>
           </CardWrapper>

--- a/src/types/problem.ts
+++ b/src/types/problem.ts
@@ -22,3 +22,7 @@ export type GetProblemListResponse = {
     next: string;
   };
 };
+
+export type CursorPaginationParams = {
+  pageParam?: string | null;
+};


### PR DESCRIPTION
## PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세
#### 해설 목록 API 연동
- 전체 문제 리스트를 실제 API를 연동하여 불러오도록 변경
- 커서 기반 페이지네이션 적용 (`useInfiniteQuery` 사용)
- 로딩 상태 처리 (`isPending`, `isFetchingNextPage`) 
- 데이터 없을 경우 `Empty` 컴포넌트 렌더링


#### 무한 스크롤 구현
- Intersection Observer 기반 무한 스크롤 구현
- 리스트 하단 요소가 뷰포트에 들어오면 자동으로 다음 페이지 요청

#### `useInfiniteScroll` 커스텀 훅
- observer 관련 로직을 훅으로 분리


https://github.com/user-attachments/assets/bcf9ac96-3038-4f9d-91a0-6bb3a0d2bc8a

