### PR TITLE
[AMT-71] 로그인 페이지 분리

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,18 +1,18 @@
-import js from "@eslint/js";
-import globals from "globals";
-import reactHooks from "eslint-plugin-react-hooks";
-import reactRefresh from "eslint-plugin-react-refresh";
-import tseslint from "typescript-eslint";
-import { globalIgnores } from "eslint/config";
+import js from '@eslint/js';
+import globals from 'globals';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import tseslint from 'typescript-eslint';
+import { globalIgnores } from 'eslint/config';
 
 export default tseslint.config([
-  globalIgnores(["dist"]),
+  globalIgnores(['dist']),
   {
-    files: ["**/*.{ts,tsx}"],
+    files: ['**/*.{ts,tsx}'],
     extends: [
       js.configs.recommended,
       tseslint.configs.recommended,
-      reactHooks.configs["recommended-latest"],
+      reactHooks.configs['recommended-latest'],
       reactRefresh.configs.vite,
     ],
     languageOptions: {
@@ -20,9 +20,9 @@ export default tseslint.config([
       globals: globals.browser,
     },
     rules: {
-      "no-var": "off", // var 키워드 사용 가능
-      "prefer-const": "warn", // 변수가 재할당 되지 않는다면 let 대신 const 사용
-      "no-redeclare": 1, // 변수 중복 선언
+      'no-var': 'on', // var 키워드 사용 가능
+      'prefer-const': 'warn', // 변수가 재할당 되지 않는다면 let 대신 const 사용
+      'no-redeclare': 1, // 변수 중복 선언
     },
   },
 ]);

--- a/src/features/users/api/useLoginMutation.ts
+++ b/src/features/users/api/useLoginMutation.ts
@@ -7,10 +7,6 @@ import type { NavigateFunction } from 'react-router-dom';
 import type { AxiosError } from 'axios';
 
 const login = async (data: userData) => {
-  console.log('로그인 요청 보내는 데이터:', {
-    username: data.username,
-    password: data.password,
-  });
   return await httpClient.post('/member/login', {
     username: data.username,
     password: data.password,

--- a/src/features/users/api/useLoginMutation.ts
+++ b/src/features/users/api/useLoginMutation.ts
@@ -21,11 +21,7 @@ const getChildInfo = async (memberId: number) => {
   return await httpClient.get(`/member/${memberId}`);
 };
 
-export const useLogin = (
-  idValue: string,
-  setIsUser: React.Dispatch<React.SetStateAction<boolean>>,
-  navigate: NavigateFunction
-) => {
+export const useLogin = (idValue: string, navigate: NavigateFunction) => {
   return useMutation({
     mutationFn: login,
     onSuccess: async (res) => {
@@ -60,6 +56,7 @@ export const useLogin = (
           id: idValue,
           childName: '김길동',
         });
+        console.error(childInfoError);
 
         toast.success('로그인 성공 (자녀 정보 조회는 실패)');
         navigate('/');
@@ -68,9 +65,10 @@ export const useLogin = (
     onError: (err: AxiosError) => {
       console.error(err);
       if (err.response?.status === 401) {
-        if (confirm('회원가입 하시겠습니까?')) setIsUser(false);
-        else toast.error('잘못 입력된 아이디 또는 비밀번호입니다.');
+        // if (confirm('회원가입 하시겠습니까?')) return;
+        // else
+        toast.error('잘못 입력된 아이디 또는 비밀번호입니다.');
       } else toast.error('알수없는 오류가 발생했습니다.');
     },
   });
-}
+};

--- a/src/features/users/components/LoginForm.tsx
+++ b/src/features/users/components/LoginForm.tsx
@@ -9,6 +9,7 @@ import type { userData } from '@/types/user.type';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useLogin } from '../api/useLoginMutation';
+import { toast } from 'sonner';
 
 type LoginFormProps = {
   watch: UseFormWatch<userData>;
@@ -29,6 +30,21 @@ export default function LoginForm({
 
   const login = useLogin(usernameValue, navigate);
 
+  const handleInputError = (
+    e: React.FormEvent<HTMLInputElement>,
+    type: string
+  ) => {
+    e.preventDefault();
+    if (type === 'id')
+      toast.error(
+        '아이디는 영어 또는 엉어와 숫자의 조합으로 3자 이상 작성해야 합니다.'
+      );
+    else if (type === 'password')
+      toast.error(
+        '비밀번호는 영어와 숫자의 조합으로 4자 이상 작성해야 합니다.'
+      );
+  };
+
   useEffect(() => {
     if (usernameValue.trim() !== '' && passwordValue.trim() !== '') {
       setIsActive(true);
@@ -42,14 +58,14 @@ export default function LoginForm({
       id='login'
       onSubmit={handleSubmit((data) => {
         login.mutate(data);
-        // 로그인 API 문제 발생 시 임시로 다음 페이지도 넘어가게 하는 용도
-        // setIsUser(false);
       })}
       className='flex flex-1 flex-col w-full gap-5 px-[33px]'
     >
       <Input
         id='username'
         placeholder='아이디를 입력하세요'
+        pattern='^(?=.*[a-zA-Z])[a-zA-Z0-9]*'
+        onInvalid={(e) => handleInputError(e, 'id')}
         className='px-[15px] py-[9px] h-[52px] box-border border-primary border-[1px] rounded-[12px]'
         {...register('username')}
         minLength={3}
@@ -60,6 +76,8 @@ export default function LoginForm({
       <Input
         type='password'
         id='password'
+        pattern='^(?=.*[a-zA-Z])(?=.*[0-9])[a-zA-Z0-9]*'
+        onInvalid={(e) => handleInputError(e, 'password')}
         placeholder='비밀번호를 입력하세요'
         minLength={4}
         className='px-[15px] py-[9px] h-[52px] box-border border-primary border-[1px] rounded-[12px]'

--- a/src/features/users/components/LoginForm.tsx
+++ b/src/features/users/components/LoginForm.tsx
@@ -1,6 +1,5 @@
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import type {
   UseFormHandleSubmit,
   UseFormRegister,
@@ -15,14 +14,12 @@ type LoginFormProps = {
   watch: UseFormWatch<userData>;
   handleSubmit: UseFormHandleSubmit<userData>;
   register: UseFormRegister<userData>;
-  setIsUser: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 export default function LoginForm({
   watch,
   handleSubmit,
   register,
-  setIsUser,
 }: LoginFormProps) {
   const [isActive, setIsActive] = useState<boolean>(false);
   const navigate = useNavigate();
@@ -30,7 +27,7 @@ export default function LoginForm({
   const usernameValue = watch('username') ?? '';
   const passwordValue = watch('password') ?? '';
 
-  const login = useLogin(usernameValue, setIsUser, navigate);
+  const login = useLogin(usernameValue, navigate);
 
   useEffect(() => {
     if (usernameValue.trim() !== '' && passwordValue.trim() !== '') {
@@ -48,30 +45,24 @@ export default function LoginForm({
         // 로그인 API 문제 발생 시 임시로 다음 페이지도 넘어가게 하는 용도
         // setIsUser(false);
       })}
-      className='flex flex-col gap-3 px-[25px]'
+      className='flex flex-col w-full gap-5 px-[33px]'
     >
-      <Label htmlFor='username' className='font-korean-title text-xl font-bold'>
-        이름
-      </Label>
       <Input
         id='username'
-        placeholder='이름을 입력하세요.'
-        className='px-[15px] py-[9px] h-[52px] box-border mb-2 border-primary border-[1px] rounded-[12px]'
+        placeholder='아이디를 입력하세요'
+        className='px-[15px] py-[9px] h-[52px] box-border border-primary border-[1px] rounded-[12px]'
         {...register('username')}
         minLength={3}
         onBlur={() => {
           if (usernameValue !== '' && passwordValue !== '') setIsActive(true);
         }}
       />
-      <Label htmlFor='password' className='font-korean-title text-xl font-bold'>
-        비밀번호
-      </Label>
       <Input
         type='password'
         id='password'
-        placeholder='******'
+        placeholder='비밀번호를 입력하세요'
         minLength={4}
-        className='px-[15px] py-[9px] h-[52px] box-border mb-2 border-primary border-[1px] rounded-[12px]'
+        className='px-[15px] py-[9px] h-[52px] box-border border-primary border-[1px] rounded-[12px]'
         {...register('password')}
         onBlur={() => {
           if (usernameValue !== '' && passwordValue !== '') setIsActive(true);
@@ -82,13 +73,9 @@ export default function LoginForm({
           isActive ? (login.isPending ? 'disabled' : 'default') : 'disabled'
         }`}
         type={`${isActive ? (login.isPending ? 'button' : 'submit') : 'button'}`}
-        className='h-[48px]'
+        className='h-[48px] mb-[55px] mt-[21vh]'
       >
-        {isActive
-          ? login.isPending
-            ? ' · · · '
-            : '로그인'
-          : '아이디 및 비밀번호를 입력해주세요.'}
+        {login.isPending ? ' · · · ' : '로그인'}
       </Button>
     </form>
   );

--- a/src/features/users/components/LoginForm.tsx
+++ b/src/features/users/components/LoginForm.tsx
@@ -45,7 +45,7 @@ export default function LoginForm({
         // 로그인 API 문제 발생 시 임시로 다음 페이지도 넘어가게 하는 용도
         // setIsUser(false);
       })}
-      className='flex flex-col w-full gap-5 px-[33px]'
+      className='flex flex-1 flex-col w-full gap-5 px-[33px]'
     >
       <Input
         id='username'
@@ -73,7 +73,7 @@ export default function LoginForm({
           isActive ? (login.isPending ? 'disabled' : 'default') : 'disabled'
         }`}
         type={`${isActive ? (login.isPending ? 'button' : 'submit') : 'button'}`}
-        className='h-[48px] mb-[55px] mt-[21vh]'
+        className='h-[48px] mt-auto'
       >
         {login.isPending ? ' · · · ' : '로그인'}
       </Button>

--- a/src/features/users/components/OnBoardingIntro.tsx
+++ b/src/features/users/components/OnBoardingIntro.tsx
@@ -1,13 +1,9 @@
-export default function OnBoardingIntro(isUser: boolean) {
-  var introMessage = isUser ? (
-    <>
-      <span className='text-primary'>일타</span>에 오신 걸 환영합니다!
-    </>
-  ) : (
+export default function OnBoardingIntro() {
+  var introMessage = (
     <>
       안녕하세요!
       <br />
-      <span className='text-primary'>일타</span>는 처음 이용하시는 군요?{' '}
+      <span className='text-primary'>일타</span>는 처음 이용하시는 군요?
     </>
   );
   return (
@@ -17,7 +13,9 @@ export default function OnBoardingIntro(isUser: boolean) {
         alt=''
         className='aspect-square size-[49px]'
       />
-      <h1 className='font-korean-title font-medium text-3xl'>{introMessage}</h1>
+      <h1 className='font-korean-title font-medium text-3xl break-keep'>
+        {introMessage}
+      </h1>
     </div>
   );
 }

--- a/src/features/users/components/OnBoardingIntro.tsx
+++ b/src/features/users/components/OnBoardingIntro.tsx
@@ -1,5 +1,5 @@
 export default function OnBoardingIntro() {
-  var introMessage = (
+  let introMessage = (
     <>
       안녕하세요!
       <br />

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -39,8 +39,8 @@ httpClient.interceptors.response.use(
   },
   (error) => {
     if (error.response?.status === 401) {
-      if (window.location.pathname !== '/onboarding') {
-        window.location.href = '/onboarding';
+      if (window.location.pathname !== '/login') {
+        window.location.href = '/login';
       }
     }
 

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -18,15 +18,15 @@ export default function LoginPage() {
   });
 
   return (
-    <>
+    <section className='h-[calc(100%-55px)]'>
       <SubHeader type='back' title='' />
-      <div className='w-full h-[calc(100%-55px)] pt-[15px] flex flex-col items-center-safe'>
+      <div className='w-full h-full pt-[15px] pb-[55px] flex flex-1 flex-col items-center-safe'>
         <img
           src='/images/logo/Logo_Img_noBg.svg'
           alt='일타_로고.svg'
           className='size-25 mx-auto'
         />
-        <h3 className='mt-2 title-md'>
+        <h3 className='mt-2 title-md '>
           <span className='text-primary'>일타</span>에 오신걸 환영해요!
         </h3>
         <p className='text-[#6D6D6D] dark:text-[#FDFBF9] body-sm mt-[13px] mb-[13vh]'>
@@ -38,6 +38,6 @@ export default function LoginPage() {
           register={register}
         />
       </div>
-    </>
+    </section>
   );
 }

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,0 +1,43 @@
+import SubHeader from '@/components/layout/SubHeader';
+import LoginForm from '@/features/users/components/LoginForm';
+import type { userData } from '@/types/user.type';
+import { useForm } from 'react-hook-form';
+
+export default function LoginPage() {
+  const {
+    register,
+    watch,
+    handleSubmit,
+    // formState: { errors },
+  } = useForm<userData>({
+    defaultValues: {
+      username: '',
+      password: '',
+    },
+    mode: 'onSubmit',
+  });
+
+  return (
+    <>
+      <SubHeader type='back' title='' />
+      <div className='w-full h-[calc(100%-55px)] pt-[15px] flex flex-col items-center-safe'>
+        <img
+          src='/images/logo/Logo_Img_noBg.svg'
+          alt='일타_로고.svg'
+          className='size-25 mx-auto'
+        />
+        <h3 className='mt-2 title-md'>
+          <span className='text-primary'>일타</span>에 오신걸 환영해요!
+        </h3>
+        <p className='text-[#6D6D6D] dark:text-[#FDFBF9] body-sm mt-[13px] mb-[13vh]'>
+          아이의 궁금증, 함께 풀어드릴게요
+        </p>
+        <LoginForm
+          watch={watch}
+          handleSubmit={handleSubmit}
+          register={register}
+        />
+      </div>
+    </>
+  );
+}

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -40,7 +40,7 @@ export default function OnboardingPage() {
           watch={watch}
           handleSubmit={handleSubmit}
           register={register}
-          setIsUser={setIsUser}
+          // setIsUser={setIsUser}
         />
       )}
       {!isUser && (

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -1,21 +1,9 @@
-import { useState } from 'react';
 import { useForm } from 'react-hook-form';
-import LoginForm from '@/features/users/components/LoginForm';
-// import ChildInfoGradeInput from '@/features/users/components/ChildInfoGradeInput';
 import OnBoardingIntro from '@/features/users/components/OnBoardingIntro';
 import ChildInfoInput from '@/features/users/components/ChildInfoInput';
 import type { userData } from '@/types/user.type';
 
-// const data = {
-//   id: 'gildongmom',
-//   password: '1q2w3e4r',
-//   childName: '고길동',
-//   childGrade: '8',
-// };
-
 export default function OnboardingPage() {
-  const [isUser, setIsUser] = useState<boolean>(true);
-
   const {
     register,
     control,
@@ -34,23 +22,13 @@ export default function OnboardingPage() {
 
   return (
     <div className='w-full h-full mt-[50px]'>
-      {OnBoardingIntro(isUser)}
-      {isUser && (
-        <LoginForm
-          watch={watch}
-          handleSubmit={handleSubmit}
-          register={register}
-          // setIsUser={setIsUser}
-        />
-      )}
-      {!isUser && (
-        <ChildInfoInput
-          watch={watch}
-          control={control}
-          handleSubmit={handleSubmit}
-          register={register}
-        />
-      )}
+      <OnBoardingIntro />
+      <ChildInfoInput
+        watch={watch}
+        control={control}
+        handleSubmit={handleSubmit}
+        register={register}
+      />
     </div>
   );
 }

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -1,9 +1,12 @@
+import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import OnBoardingIntro from '@/features/users/components/OnBoardingIntro';
 import ChildInfoInput from '@/features/users/components/ChildInfoInput';
 import type { userData } from '@/types/user.type';
 
 export default function OnboardingPage() {
+  const [isUser, setIsUser] = useState<boolean>(false);
+
   const {
     register,
     control,
@@ -22,13 +25,15 @@ export default function OnboardingPage() {
 
   return (
     <div className='w-full h-full mt-[50px]'>
-      <OnBoardingIntro />
-      <ChildInfoInput
-        watch={watch}
-        control={control}
-        handleSubmit={handleSubmit}
-        register={register}
-      />
+      {OnBoardingIntro()}
+      {!isUser && (
+        <ChildInfoInput
+          watch={watch}
+          control={control}
+          handleSubmit={handleSubmit}
+          register={register}
+        />
+      )}
     </div>
   );
 }

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -1,12 +1,9 @@
-import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import OnBoardingIntro from '@/features/users/components/OnBoardingIntro';
 import ChildInfoInput from '@/features/users/components/ChildInfoInput';
 import type { userData } from '@/types/user.type';
 
 export default function OnboardingPage() {
-  const [isUser, setIsUser] = useState<boolean>(false);
-
   const {
     register,
     control,
@@ -26,14 +23,12 @@ export default function OnboardingPage() {
   return (
     <div className='w-full h-full mt-[50px]'>
       {OnBoardingIntro()}
-      {!isUser && (
-        <ChildInfoInput
-          watch={watch}
-          control={control}
-          handleSubmit={handleSubmit}
-          register={register}
-        />
-      )}
+      <ChildInfoInput
+        watch={watch}
+        control={control}
+        handleSubmit={handleSubmit}
+        register={register}
+      />
     </div>
   );
 }

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -5,6 +5,7 @@ import RequireAuth from './utils/RequireAuth.tsx';
 const Layout = lazy(() => import('./components/layout/Layout'));
 const HomePage = lazy(() => import('./pages/HomePage'));
 const MyPage = lazy(() => import('./pages/MyPage'));
+const LoginPage = lazy(() => import('./pages/LoginPage'));
 const OnboardingPage = lazy(() => import('./pages/OnboardingPage'));
 const ProblemHistoryPage = lazy(() => import('./pages/ProblemHistoryPage'));
 const ProblemUploadPage = lazy(() => import('./pages/ProblemUploadPage'));
@@ -41,6 +42,14 @@ const router = createBrowserRouter([
         element: (
           <RequireAuth>
             <OnboardingPage />
+          </RequireAuth>
+        ),
+      },
+      {
+        path: '/login',
+        element: (
+          <RequireAuth>
+            <LoginPage />
           </RequireAuth>
         ),
       },

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -57,7 +57,9 @@ const router = createBrowserRouter([
         path: '/history',
         element: (
           <BasicLayout>
-            <ProblemHistoryPage />
+            <RequireAuth>
+              <ProblemHistoryPage />
+            </RequireAuth>
           </BasicLayout>
         ),
       },
@@ -65,7 +67,9 @@ const router = createBrowserRouter([
         path: '/profile',
         element: (
           <BasicLayout>
-            <MyPage />
+            <RequireAuth>
+              <MyPage />
+            </RequireAuth>
           </BasicLayout>
         ),
       },
@@ -83,11 +87,19 @@ const router = createBrowserRouter([
           },
           {
             path: ':_id',
-            element: <ProblemDetailPage />,
+            element: (
+              <RequireAuth>
+                <ProblemDetailPage />
+              </RequireAuth>
+            ),
           },
           {
             path: 'upload',
-            element: <ProblemUploadPage />,
+            element: (
+              <RequireAuth>
+                <ProblemUploadPage />
+              </RequireAuth>
+            ),
           },
         ],
       },

--- a/src/utils/RequireAuth.tsx
+++ b/src/utils/RequireAuth.tsx
@@ -10,11 +10,14 @@ export default function RequireAuth({
 
   if (!user) {
     if (window.location.pathname === '/')
-      return <Navigate to='/onboarding' replace />;
+      return <Navigate to='/login' replace />;
   }
 
   if (user) {
-    if (window.location.pathname === '/onboarding')
+    if (
+      window.location.pathname === '/onboarding' ||
+      window.location.pathname === '/login'
+    )
       return <Navigate to='/' replace />;
   }
 

--- a/src/utils/RequireAuth.tsx
+++ b/src/utils/RequireAuth.tsx
@@ -9,7 +9,10 @@ export default function RequireAuth({
   const user = useUserStore((store: userStore) => store.user);
 
   if (!user) {
-    if (window.location.pathname === '/')
+    if (
+      window.location.pathname !== '/login' &&
+      window.location.pathname !== '/onboarding'
+    )
       return <Navigate to='/login' replace />;
   }
 

--- a/src/utils/handle-api-error.ts
+++ b/src/utils/handle-api-error.ts
@@ -15,7 +15,7 @@ export function handleApiError(error: unknown) {
   } else if (status === 401) {
     toast.error('로그인이 필요합니다.');
     setTimeout(() => {
-      window.location.href = '/onboarding';
+      window.location.href = '/login';
     }, 1500);
   } else if (status === 404) {
     toast.error('데이터를 찾을 수 없습니다.');


### PR DESCRIPTION
## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세

- 로그인 페이지 분리 및 미 로그인 시 리다이렉트 /login으로 변경



<img width="369" height="383" alt="image" src="https://github.com/user-attachments/assets/c17252a1-310e-4337-a12a-c6975d0b22ff" />
<img width="363" height="451" alt="image" src="https://github.com/user-attachments/assets/7a52d5da-3ff2-4f26-ae98-2b3552cb04ec" />

- ID 및 비밀번호 영어 또는 숫자로만 입력받게 수정. ID는 영어 또는 영어+숫자, 비밀번호는 영어+숫자로 강제



<img width="275" height="186" alt="image" src="https://github.com/user-attachments/assets/5d36683d-7e86-44cc-bd84-b5699480886e" />

- 미 로그인 상태에서 다른 페이지에 접근할 수 있던 문제 수정. API 서버가 다운된 상태에서 해당 페이지에 접근하여 테스트 할 시 src/routes.tsx의 해당 path의 element에 있는 <RequireAuth> </RequireAuth> 만 주석처리 하면 됨
