### PR TITLE
[AMT-76] 랜딩 페이지 라우팅 설정

### DIFF
--- a/src/components/layout/RequireAuth.tsx
+++ b/src/components/layout/RequireAuth.tsx
@@ -1,5 +1,5 @@
 import { Navigate } from 'react-router-dom';
-import useUserStore, { type userStore } from '../stores/userStore';
+import useUserStore, { type userStore } from '../../stores/userStore';
 
 export default function RequireAuth({
   children,
@@ -10,16 +10,18 @@ export default function RequireAuth({
 
   if (!user) {
     if (
+      window.location.pathname !== '/intro' &&
       window.location.pathname !== '/login' &&
       window.location.pathname !== '/onboarding'
     )
-      return <Navigate to='/login' replace />;
+      return <Navigate to='/intro' replace />;
   }
 
   if (user) {
     if (
       window.location.pathname === '/onboarding' ||
-      window.location.pathname === '/login'
+      window.location.pathname === '/login' ||
+      window.location.pathname === '/intro'
     )
       return <Navigate to='/' replace />;
   }

--- a/src/features/users/components/LandingTypeA.tsx
+++ b/src/features/users/components/LandingTypeA.tsx
@@ -3,11 +3,11 @@ import { Link } from 'react-router-dom';
 export default function LandingTypeA() {
   return (
     <section className='relative h-full w-full px-5'>
-      <div className='pointer-events-none w-[380px] fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-2/5 z-10 star-pulse'>
+      <div className='pointer-events-none w-[380px] fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-2/5 z-0 star-pulse'>
         <img src='/images/Star_Yellow.svg' alt='star' className='w-full z-0' />
       </div>
 
-      <section className='relative flex flex-col gap-3 z-50'>
+      <section className='relative flex flex-col gap-3 z-50 will-change-transform'>
         <h1 className='title-md z-50'>
           "엄마, 이거 어떻게 풀어?"
           <br />

--- a/src/features/users/components/LandingTypeA.tsx
+++ b/src/features/users/components/LandingTypeA.tsx
@@ -1,24 +1,26 @@
+import { Link } from 'react-router-dom';
+
 export default function LandingTypeA() {
   return (
-    <section className='relative h-full w-full px-5 '>
-      <div className='relative flex flex-col gap-3 z-100'>
+    <section className='relative h-full w-full px-5'>
+      <section className='relative flex flex-col gap-3 z-100'>
         <h1 className='title-md'>
           "엄마, 이거 어떻게 풀어?"
           <br />
           <span className='text-primary'>AI</span>가 부모님께
           <br />
-          <span className='text-primary'>설명방법을</span> 알려드려요{''}
+          <span className='text-primary'>설명방법을</span> 알려드려요
         </h1>
-        <div className='text-gray5 dark:text-gray2 body-md'>
+        <div className='text-gray5 dark:text-gray4 body-md z-100'>
           어려운 수학 문제, 이제 쉽게 설명해줄 수 있어요
         </div>
-      </div>
+      </section>
+
       <div className='w-[380px] fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-2/5 z-0 star-pulse'>
-        <img src='/images/Star_Yellow.svg' alt='star' className='w-full' />
+        <img src='/images/Star_Yellow.svg' alt='star' className='w-full z-0' />
       </div>
-      {/* 도형들 컨테이너 - 배경 별 안쪽에 배치 */}
-      <div className='absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-2/5 w-80 h-96 z-10'>
-        {/* 초록 사각형 - 왼쪽 위 */}
+
+      <section className='absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-2/5 w-80 h-96 z-10'>
         <div className='absolute top-13 left-0 rotate-green'>
           <img
             src='/images/characters/green.svg'
@@ -27,7 +29,6 @@ export default function LandingTypeA() {
           />
         </div>
 
-        {/* 노랑 도형 - 오른쪽 위 */}
         <div className='absolute top-20 right-3 rotate-yellow'>
           <img
             src='/images/characters/yellow.svg'
@@ -43,17 +44,19 @@ export default function LandingTypeA() {
             className='w-30 h-30 transform rotate-[-15deg]'
           />
         </div>
-      </div>
-      <div className='absolute bottom-0 left-1/2 -translate-x-1/2 z-10'>
-        <div className='flex flex-col items-center gap-4 z-100'>
-          <div className='w-12 h-12 rounded-md flex items-center justify-center'>
-            <img src='/images/Kakao.svg' alt='kakao' className='w-45 h-45' />
-          </div>
-          <div className='text-gray5 dark:text-gray2 body-md' >
-            아이디로 로그인할래요!
-          </div>
-        </div>
-      </div>
+      </section>
+
+      <section className='absolute bottom-0 left-1/2 -translate-x-1/2 flex flex-col items-center gap-4 z-100'>
+        <button className='w-12 h-12 rounded-md flex items-center justify-center cursor-pointer hover:scale-110 active:scale-110 duration-150 ease-in'>
+          <img src='/images/Kakao.svg' alt='kakao' className='w-45 h-45' />
+        </button>
+        <Link
+          to='/login'
+          className='text-gray5 dark:text-gray2 body-sm cursor-pointer hover:scale-110 hover:text-black dark:hover:text-white active:scale-110 active:text-black dark:active:text-white duration-150 ease-in'
+        >
+          아이디로 로그인할래요!
+        </Link>
+      </section>
     </section>
   );
 }

--- a/src/features/users/components/LandingTypeA.tsx
+++ b/src/features/users/components/LandingTypeA.tsx
@@ -3,22 +3,22 @@ import { Link } from 'react-router-dom';
 export default function LandingTypeA() {
   return (
     <section className='relative h-full w-full px-5'>
-      <section className='relative flex flex-col gap-3 z-100'>
-        <h1 className='title-md'>
+      <div className='pointer-events-none w-[380px] fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-2/5 z-10 star-pulse'>
+        <img src='/images/Star_Yellow.svg' alt='star' className='w-full z-0' />
+      </div>
+
+      <section className='relative flex flex-col gap-3 z-50'>
+        <h1 className='title-md z-50'>
           "엄마, 이거 어떻게 풀어?"
           <br />
           <span className='text-primary'>AI</span>가 부모님께
           <br />
           <span className='text-primary'>설명방법을</span> 알려드려요
         </h1>
-        <div className='text-gray5 dark:text-gray4 body-md z-100'>
+        <p className='text-gray5 dark:text-gray4 body-md z-50'>
           어려운 수학 문제, 이제 쉽게 설명해줄 수 있어요
-        </div>
+        </p>
       </section>
-
-      <div className='w-[380px] fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-2/5 z-0 star-pulse'>
-        <img src='/images/Star_Yellow.svg' alt='star' className='w-full z-0' />
-      </div>
 
       <section className='absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-2/5 w-80 h-96 z-10'>
         <div className='absolute top-13 left-0 rotate-green'>

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -2,8 +2,8 @@ import LandingTypeA from '@/features/users/components/LandingTypeA';
 
 export default function OnboardingPage() {
   return (
-    <div className='w-full h-full py-10'>
+    <section className='w-full h-full py-10'>
       <LandingTypeA />
-    </div>
+    </section>
   );
 }

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -40,7 +40,11 @@ const router = createBrowserRouter([
       },
       {
         path: '/intro',
-        element: <LandingPage />,
+        element: (
+          <RequireAuth>
+            <LandingPage />
+          </RequireAuth>
+        ),
       },
       {
         path: '/onboarding',

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,6 +1,5 @@
 import { lazy } from 'react';
 import { createBrowserRouter, Outlet } from 'react-router-dom';
-import RequireAuth from './utils/RequireAuth.tsx';
 
 const Layout = lazy(() => import('./components/layout/Layout'));
 const HomePage = lazy(() => import('./pages/HomePage'));
@@ -15,6 +14,7 @@ const ErrorPage = lazy(() => import('./pages/NotFoundPage'));
 const MockApiPage = lazy(() => import('./MockApiPage.tsx'));
 const LayoutWrapper = lazy(() => import('./components/layout/LayoutWrapper'));
 const BasicLayout = lazy(() => import('./components/layout/BasicLayout'));
+const RequireAuth = lazy(() => import('./components/layout/RequireAuth.tsx'));
 
 const router = createBrowserRouter([
   {

--- a/src/utils/handle-api-error.ts
+++ b/src/utils/handle-api-error.ts
@@ -15,7 +15,7 @@ export function handleApiError(error: unknown) {
   } else if (status === 401) {
     toast.error('로그인이 필요합니다.');
     setTimeout(() => {
-      window.location.href = '/login';
+      window.location.href = '/intro';
     }, 1500);
   } else if (status === 404) {
     toast.error('데이터를 찾을 수 없습니다.');


### PR DESCRIPTION
## PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세
#### 랜딩페이지 라우팅 로직 개선
- 로그인하지 않은 사용자가 `/intro`, `/login`, `/onboarding` 외의 페이지에 접근 시 `/intro`로 리다이렉트 되도록 설정했습니다.
- 로그인한 사용자가 해당 페이지들에 접근하려고 하면 `/`로 이동하도록 설정했습니다.

#### 랜딩페이지에 로그인 링크 추가
- 하단 "아이디로 로그인할래요" 버튼 클릭 시 로그인 페이지(`/login`)로 이동하도록 링크를 추가했습니다.
- 해당 버튼에 hover 및 active 시 살짝 커지는 효과를 추가했습니다.

#### 별(star) 배경이 텍스트를 가리는 문제 해결
- 텍스트 영역에 `will-change-transform` 클래스를 추가해서 배경 요소 위에 정상적으로 렌더링되도록 수정했습니다.



https://github.com/user-attachments/assets/6a56d7be-d21d-4f50-8bf4-f3f35080b301


https://github.com/user-attachments/assets/03c93891-3894-4dcf-bfb1-ffcef18560e7

