### PR TITLE
[AMT-93] ProblemResponseDto 필드 변경에 따른 타입 수정

### DIFF
--- a/src/features/problems/list/GridView.tsx
+++ b/src/features/problems/list/GridView.tsx
@@ -34,7 +34,7 @@ export default function GridView({ items }: GridViewProps) {
               </button>
               <div className='flex justify-end'>
                 <p className='label text-gray5 dark:text-gray2 pt-4 pr-4'>
-                  {formatListDate(item.createdAt)}
+                  {formatListDate(item.activatedAt)}
                 </p>
               </div>
               <img

--- a/src/features/problems/list/ListView.tsx
+++ b/src/features/problems/list/ListView.tsx
@@ -28,7 +28,7 @@ export default function ListView({ items }: ListViewProps) {
                 fill={item.favorite ? 'currentColor' : 'none'}
                 onClick={handleToggle}
               />
-              <Title size='md'>{item.ocrResult}</Title>
+              <Title size='md'>{item.summary}</Title>
               <p className='body-sm text-gray5 dark:text-gray2 overflow-hidden text-ellipsis whitespace-nowrap'>
                 {item.concepts.map((concept) => (
                   <span key={concept.id} className='ml-1'>
@@ -37,7 +37,7 @@ export default function ListView({ items }: ListViewProps) {
                 ))}
               </p>
               <p className='label text-gray5 dark:text-gray2'>
-                {formatListDate(item.createdAt)}
+                {formatListDate(item.activatedAt)}
               </p>
             </div>
           </CardWrapper>

--- a/src/pages/ProblemDetailPage.tsx
+++ b/src/pages/ProblemDetailPage.tsx
@@ -50,7 +50,7 @@ export default function ProblemDetailPage() {
       <SubHeader type='back' title='해설 보기' />
       <main className='flex-1 flex flex-col gap-4 py-3 px-6'>
         <p className='text-right label text-gray5 dark:text-gray2'>
-          {formatDetailDate(data.createdAt)}
+          {formatDetailDate(data.activatedAt)}
         </p>
         <ImageSection url={data.imageUrl} alt={String(data.id)} />
         <DetailSection>
@@ -60,7 +60,7 @@ export default function ProblemDetailPage() {
               remarkPlugins={[remarkMath, remarkGfm]}
               rehypePlugins={[rehypeKatex]}
             >
-              {data.ocrResult}
+              {data.summary}
             </Markdown>
           </CardWrapper>
         </DetailSection>
@@ -84,7 +84,7 @@ export default function ProblemDetailPage() {
               remarkPlugins={[remarkMath, remarkGfm]}
               rehypePlugins={[rehypeKatex]}
             >
-              {sanitizeMathMarkdown(data.llmResult)}
+              {sanitizeMathMarkdown(data.explanation)}
             </Markdown>
           </CardWrapper>
         </DetailSection>

--- a/src/types/problem.type.ts
+++ b/src/types/problem.type.ts
@@ -6,8 +6,9 @@ export type Problem = {
   concepts: Omit<Concept, 'description'>[];
   favorite: boolean;
   ocrResult: string;
-  llmResult: string;
-  createdAt: string;
+  summary: string;
+  explanation: string;
+  activatedAt: string;
 };
 
 export type GetProblemListResponse = {


### PR DESCRIPTION
# ProblemResponseDto 필드 변경에 따른 타입 수정

## PR 상세
* `summary` 필드 추가

  * `ocrResult`의 요약 버전으로 사용
  * **프론트에서는 `ocrResult` 대신 `summary`를 사용자에게 보여줄 예정**

* `ocrResult` 필드 유지 (백엔드에서 추출된 OCR 원문)

* `llmResult` → `explanation`으로 필드명 변경

  * LLM이 생성한 설명 결과를 의미하도록 명확하게 네이밍 수정

* `createdAt` → `activatedAt`으로 필드명 변경

  * 기존의 "문제 생성 시점"이 아닌, **AI 생성 완료 후 실제로 사용자에게 노출되는 시점**을 기준으로 변경

> ⚠️ 추후 `ocrResult`의 품질이 높아질 경우, `summary` 필드 유지 여부는 다시 검토 예정입니다.

```json
{
    "id": 77,
    "imageUrl": "https://raoocnulfuuhnuiftdmp.supabase.co/storage/v1/object/public/ilta-images/8/a6192188-827b-43d6-bf69-5df16ab20454.png",
    "concepts": [
        {
            "id": 60,
            "name": "반비례 관계"
        },
        {
            "id": 71,
            "name": "좌표"
        },
        {
            "id": 72,
            "name": "그래프"
        }
    ],
    "favorite": false,
    "ocrResult": "반비례 관계7= £ (a4 0,x>0)2| 그래프이다. 그래프\n\n6일 때, ;좌표의 차가 4이다. 이때\n\n_4@\nvey",
    "summary": "반비례 관계 그래프에서 좌표 차이를 구하는 문제",
    "explanation": "이 문제는 반비례 관계의 그래프에서 특정 좌표를 찾고 그 차이를 구하는 것입니다. 반비례 관계는 $y = \\frac{k}{x}$ 형태로 나타납니다. 여기서 $k$는 상수입니다. 주어진 정보에 따라 $x$와 $y$의 값을 찾고, 두 점의 좌표 차이를 계산하면 됩니다.",
    "activatedAt": "2025-07-27T12:21:16.553986"
}
```

## PR 유형

- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
