### PR TITLE
[AMT-85] 즐겨찾기/개념 API 연동

### DIFF
--- a/src/features/concepts/api/get-concept.ts
+++ b/src/features/concepts/api/get-concept.ts
@@ -1,0 +1,16 @@
+import { httpClient } from '@/lib/api-client';
+import { type Concept } from '@/types/concept.type';
+import { conceptKey } from '@/utils/query-key';
+import { useQuery } from '@tanstack/react-query';
+
+const getConcept = async (id: number) => {
+  const res = await httpClient.get<Concept>(`/concept?conceptId=${id}`);
+  return res.data;
+};
+
+export const useConcept = (id: number) => {
+  return useQuery({
+    queryKey: conceptKey(String(id)),
+    queryFn: () => getConcept(id),
+  });
+};

--- a/src/features/concepts/components/ConceptList.tsx
+++ b/src/features/concepts/components/ConceptList.tsx
@@ -20,8 +20,8 @@ export default function ConceptList({
           className='text-primary cursor-pointer'
           onClick={() =>
             openModal('CONCEPT', {
+              id: concept.id,
               title: concept.name,
-              description: 'description',
             })
           }
         >

--- a/src/features/concepts/components/ConceptModal.tsx
+++ b/src/features/concepts/components/ConceptModal.tsx
@@ -30,12 +30,12 @@ export default function ConceptModal({
           <DialogTitle className='title-sm'># {title}</DialogTitle>
         </DialogHeader>
         {isPending ? (
-          <ListLoading description='개념을 요약하고 있어요...' />
+          <ListLoading description='개념을 불러오는 중이에요...' />
         ) : (
           <>
             <p className='whitespace-pre-wrap body-sm'>
               {data?.description ||
-                '🤔 곧 이 개념에 대한 설명이 추가될 예정이에요.'}
+                '🤔 이 개념에 대한 설명이 곧 추가될 예정이에요.'}
             </p>
           </>
         )}

--- a/src/features/concepts/components/ConceptModal.tsx
+++ b/src/features/concepts/components/ConceptModal.tsx
@@ -2,24 +2,43 @@ import { Button } from '@/components/ui/button';
 import { DialogFooter, DialogHeader } from '@/components/ui/dialog';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import type { BaseModalProps } from '@/types/modal.type';
+import { useConcept } from '../api/get-concept';
+import ListLoading from '@/components/ui/ListLoading';
+import { handleApiError } from '@/utils/handle-api-error';
 
 export interface ConceptModalProps extends BaseModalProps {
+  id: number;
   title: string;
-  description: string;
 }
 
 export default function ConceptModal({
+  id,
   title,
-  description,
   onClose,
 }: ConceptModalProps) {
+  const { data, isPending, isError, error } = useConcept(id);
+
+  if (isError) {
+    onClose();
+    handleApiError(error);
+  }
+
   return (
     <Dialog defaultOpen onOpenChange={onClose}>
       <DialogContent className='flex flex-col items-center gap-6'>
         <DialogHeader>
           <DialogTitle className='title-sm'># {title}</DialogTitle>
         </DialogHeader>
-        <p className='whitespace-pre-wrap body-sm'>{description}</p>
+        {isPending ? (
+          <ListLoading description='개념을 요약하고 있어요...' />
+        ) : (
+          <>
+            <p className='whitespace-pre-wrap body-sm'>
+              {data?.description ||
+                '🤔 곧 이 개념에 대한 설명이 추가될 예정이에요.'}
+            </p>
+          </>
+        )}
         <DialogFooter>
           <Button onClick={onClose} size='sm'>
             닫기

--- a/src/features/problems/api/delete-problem.ts
+++ b/src/features/problems/api/delete-problem.ts
@@ -4,6 +4,7 @@ import { handleApiError } from '@/utils/handle-api-error';
 import { useMutation } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import type { GetProblemListResponse } from '@/types/problem.type';
+import { problemListKey } from '@/utils/query-key';
 
 const deleteProblem = async (id: string) => {
   const res = await httpClient.delete(`/problem?problemId=${id}`);
@@ -11,36 +12,47 @@ const deleteProblem = async (id: string) => {
 };
 
 export const useDeleteProblem = () => {
+  const keys = [
+    problemListKey({ favorite: false }),
+    problemListKey({ favorite: true }),
+  ];
+
   return useMutation({
     mutationFn: deleteProblem,
 
     onMutate: async (id: string) => {
-      await queryClient.cancelQueries({ queryKey: ['problemList'] });
+      await Promise.all(
+        keys.map((key) => queryClient.cancelQueries({ queryKey: key })),
+      );
 
-      const prevData = queryClient.getQueryData<{
-        pages: GetProblemListResponse[];
-        pageParams: any[];
-      }>(['problemList']);
+      const prevData = keys.map((key) => ({
+        key,
+        data: queryClient.getQueryData<{
+          pages: GetProblemListResponse[];
+          pageParams: any[];
+        }>(key),
+      }));
 
-      queryClient.setQueryData(['problemList'], (old: any) => {
-        if (!old) return old;
-
-        return {
-          ...old,
-          pages: old.pages.map((page: GetProblemListResponse) => ({
-            ...page,
-            data: page.data.filter((problem) => problem.id !== Number(id)),
-          })),
-        };
+      keys.forEach((key) => {
+        queryClient.setQueryData(key, (old: any) => {
+          if (!old) return old;
+          return {
+            ...old,
+            pages: old.pages.map((page: GetProblemListResponse) => ({
+              ...page,
+              data: page.data.filter((problem) => problem.id !== Number(id)),
+            })),
+          };
+        });
       });
 
       return { prevData };
     },
 
     onError: (error, _id, context) => {
-      if (context?.prevData) {
-        queryClient.setQueryData(['problemList'], context.prevData);
-      }
+      context?.prevData?.forEach(({ key, data }) => {
+        queryClient.setQueryData(key, data);
+      });
       handleApiError(error);
     },
 
@@ -49,7 +61,9 @@ export const useDeleteProblem = () => {
     },
 
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: ['problemList'] });
+      keys.forEach((key) => {
+        queryClient.invalidateQueries({ queryKey: key });
+      });
     },
   });
 };

--- a/src/features/problems/api/get-favorite-list.ts
+++ b/src/features/problems/api/get-favorite-list.ts
@@ -1,0 +1,34 @@
+import { httpClient } from '@/lib/api-client';
+import type {
+  CursorPaginationParams,
+  GetProblemListResponse,
+} from '@/types/problem.type';
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+const getFavoriteList = async ({ pageParam }: CursorPaginationParams) => {
+  const res = await httpClient.get<GetProblemListResponse>(
+    `/favorite/list?limit=10&memberId=8${pageParam ? `&after_cursor=${pageParam}` : ''}`,
+  );
+
+  const updatedData = res.data.data.map((item) => ({
+    ...item,
+    favorite: true,
+  }));
+
+  return {
+    ...res.data,
+    data: updatedData,
+  };
+};
+
+export const useFavoriteList = () => {
+  return useInfiniteQuery({
+    queryKey: ['problemList', { favorite: true }],
+    queryFn: getFavoriteList,
+    initialPageParam: '',
+    getNextPageParam: (lastPage) =>
+      lastPage.pagination.hasNextPage
+        ? lastPage.pagination.nextCursor
+        : undefined,
+  });
+};

--- a/src/features/problems/api/get-favorite-list.ts
+++ b/src/features/problems/api/get-favorite-list.ts
@@ -1,19 +1,20 @@
 import { httpClient } from '@/lib/api-client';
 import type {
   CursorPaginationParams,
-  GetProblemListResponse,
+  GetFavoriteListResponse,
 } from '@/types/problem.type';
 import { problemListKey } from '@/utils/query-key';
 import { useInfiniteQuery } from '@tanstack/react-query';
 
 const getFavoriteList = async ({ pageParam }: CursorPaginationParams) => {
-  const res = await httpClient.get<GetProblemListResponse>(
+  const res = await httpClient.get<GetFavoriteListResponse>(
     `/favorite/list?limit=10&memberId=8${pageParam ? `&after_cursor=${pageParam}` : ''}`,
   );
 
   const updatedData = res.data.data.map((item) => ({
     ...item,
     favorite: true,
+    id: item.problemId,
   }));
 
   return {

--- a/src/features/problems/api/get-favorite-list.ts
+++ b/src/features/problems/api/get-favorite-list.ts
@@ -3,6 +3,7 @@ import type {
   CursorPaginationParams,
   GetProblemListResponse,
 } from '@/types/problem.type';
+import { problemListKey } from '@/utils/query-key';
 import { useInfiniteQuery } from '@tanstack/react-query';
 
 const getFavoriteList = async ({ pageParam }: CursorPaginationParams) => {
@@ -23,7 +24,7 @@ const getFavoriteList = async ({ pageParam }: CursorPaginationParams) => {
 
 export const useFavoriteList = () => {
   return useInfiniteQuery({
-    queryKey: ['problemList', { favorite: true }],
+    queryKey: problemListKey({ favorite: true }),
     queryFn: getFavoriteList,
     initialPageParam: '',
     getNextPageParam: (lastPage) =>

--- a/src/features/problems/api/get-problem-detail.ts
+++ b/src/features/problems/api/get-problem-detail.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { httpClient } from '@/lib/api-client';
 import { type Problem } from '@/types/problem.type';
+import { problemDetailKey } from '@/utils/query-key';
 
 const getProblemDetail = async (id: string) => {
   const res = await httpClient.get<Problem>(`/problem?problemId=${id}`);
@@ -9,7 +10,7 @@ const getProblemDetail = async (id: string) => {
 
 export const useProblemDetail = (id: string) => {
   return useQuery({
-    queryKey: ['problemDetail', id],
+    queryKey: problemDetailKey(id),
     queryFn: () => getProblemDetail(id),
   });
 };

--- a/src/features/problems/api/get-problem-list.ts
+++ b/src/features/problems/api/get-problem-list.ts
@@ -14,7 +14,7 @@ const getProblemList = async ({ pageParam }: CursorPaginationParams) => {
 
 export const useProblemList = () => {
   return useInfiniteQuery({
-    queryKey: ['problemList'],
+    queryKey: ['problemList', { favorite: false }],
     queryFn: getProblemList,
     initialPageParam: '',
     getNextPageParam: (lastPage) =>

--- a/src/features/problems/api/get-problem-list.ts
+++ b/src/features/problems/api/get-problem-list.ts
@@ -3,6 +3,7 @@ import {
   type CursorPaginationParams,
   type GetProblemListResponse,
 } from '@/types/problem.type';
+import { problemListKey } from '@/utils/query-key';
 import { useInfiniteQuery } from '@tanstack/react-query';
 
 const getProblemList = async ({ pageParam }: CursorPaginationParams) => {
@@ -14,7 +15,7 @@ const getProblemList = async ({ pageParam }: CursorPaginationParams) => {
 
 export const useProblemList = () => {
   return useInfiniteQuery({
-    queryKey: ['problemList', { favorite: false }],
+    queryKey: problemListKey({ favorite: false }),
     queryFn: getProblemList,
     initialPageParam: '',
     getNextPageParam: (lastPage) =>

--- a/src/features/problems/api/toggle-favorite.ts
+++ b/src/features/problems/api/toggle-favorite.ts
@@ -1,0 +1,23 @@
+import { httpClient } from '@/lib/api-client';
+import { queryClient } from '@/lib/react-query';
+import { handleApiError } from '@/utils/handle-api-error';
+import { useMutation } from '@tanstack/react-query';
+
+const toggleFavorite = async (id: string) => {
+  const res = await httpClient.post(`/favorite?problemId=${id}`);
+  return res.data;
+};
+
+export const useToggleFAvorite = () => {
+  return useMutation({
+    mutationFn: toggleFavorite,
+
+    onError: (error) => {
+      handleApiError(error);
+    },
+
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['problemList'] });
+    },
+  });
+};

--- a/src/features/problems/api/toggle-favorite.ts
+++ b/src/features/problems/api/toggle-favorite.ts
@@ -1,6 +1,7 @@
 import { httpClient } from '@/lib/api-client';
 import { queryClient } from '@/lib/react-query';
 import { handleApiError } from '@/utils/handle-api-error';
+import { problemListKey } from '@/utils/query-key';
 import { useMutation } from '@tanstack/react-query';
 
 const toggleFavorite = async (id: string) => {
@@ -17,7 +18,12 @@ export const useToggleFAvorite = () => {
     },
 
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: ['problemList'] });
+      queryClient.invalidateQueries({
+        queryKey: problemListKey({ favorite: true }),
+      });
+      queryClient.invalidateQueries({
+        queryKey: problemListKey({ favorite: false }),
+      });
     },
   });
 };

--- a/src/features/problems/api/toggle-favorite.ts
+++ b/src/features/problems/api/toggle-favorite.ts
@@ -1,29 +1,175 @@
-import { httpClient } from '@/lib/api-client';
-import { queryClient } from '@/lib/react-query';
-import { handleApiError } from '@/utils/handle-api-error';
-import { problemListKey } from '@/utils/query-key';
 import { useMutation } from '@tanstack/react-query';
+import { queryClient } from '@/lib/react-query';
+import { httpClient } from '@/lib/api-client';
+import { handleApiError } from '@/utils/handle-api-error';
+import { problemDetailKey, problemListKey } from '@/utils/query-key';
+import {
+  type GetProblemListResponse,
+  type Problem,
+} from '@/types/problem.type';
+import { toast } from 'sonner';
 
-const toggleFavorite = async (id: string) => {
+// API 호출 함수
+const toggleFavorite = async (id: number) => {
   const res = await httpClient.post(`/favorite?problemId=${id}`);
   return res.data;
 };
 
-export const useToggleFAvorite = () => {
-  return useMutation({
+// cache 핸들링 함수 모음
+const cancelProblemListQueries = async () => {
+  await queryClient.cancelQueries({
+    queryKey: problemListKey({ favorite: true }),
+  });
+  await queryClient.cancelQueries({
+    queryKey: problemListKey({ favorite: false }),
+  });
+};
+
+const getProblemListData = () => {
+  const favoriteData = queryClient.getQueryData<{
+    pages: GetProblemListResponse[];
+    pageParams: any[];
+  }>(problemListKey({ favorite: true }));
+
+  const nonFavoriteData = queryClient.getQueryData<{
+    pages: GetProblemListResponse[];
+    pageParams: any[];
+  }>(problemListKey({ favorite: false }));
+
+  return { favoriteData, nonFavoriteData };
+};
+
+const updateProblemListCache = (
+  id: number,
+  newFavoriteValue: boolean,
+  target: GetProblemListResponse['data'][number],
+) => {
+  const favoriteKey = problemListKey({ favorite: true });
+  const nonFavoriteKey = problemListKey({ favorite: false });
+
+  queryClient.setQueryData(nonFavoriteKey, (old: any) => {
+    if (!old) return old;
+    return {
+      ...old,
+      pages: old.pages.map((page: GetProblemListResponse) => ({
+        ...page,
+        data: page.data.map((problem) =>
+          problem.id === id
+            ? { ...problem, favorite: newFavoriteValue }
+            : problem,
+        ),
+      })),
+    };
+  });
+
+  queryClient.setQueryData(favoriteKey, (old: any) => {
+    if (!old) return old;
+    return {
+      ...old,
+      pages: old.pages.map((page: GetProblemListResponse, idx: number) => {
+        if (newFavoriteValue && idx === 0) {
+          return {
+            ...page,
+            data: [{ ...target, favorite: true }, ...page.data],
+          };
+        } else {
+          return {
+            ...page,
+            data: page.data.filter((problem) => problem.id !== id),
+          };
+        }
+      }),
+    };
+  });
+};
+
+const updateProblemDetailCache = (id: number, newFavoriteValue: boolean) => {
+  queryClient.setQueryData(problemDetailKey(String(id)), (old: any) => {
+    if (!old) return old;
+    return { ...old, favorite: newFavoriteValue };
+  });
+};
+
+const restoreProblemListCache = (
+  favoriteData?: unknown,
+  nonFavoriteData?: unknown,
+) => {
+  queryClient.setQueryData(problemListKey({ favorite: true }), favoriteData);
+  queryClient.setQueryData(
+    problemListKey({ favorite: false }),
+    nonFavoriteData,
+  );
+};
+
+const invalidateProblemList = () => {
+  queryClient.invalidateQueries({
+    queryKey: problemListKey({ favorite: true }),
+  });
+  queryClient.invalidateQueries({
+    queryKey: problemListKey({ favorite: false }),
+  });
+};
+
+const invalidateProblemDetail = (id: string) => {
+  queryClient.invalidateQueries({
+    queryKey: problemDetailKey(id),
+  });
+};
+
+// toggle 훅
+export const useToggleFavorite = () => {
+  const mutation = useMutation({
     mutationFn: toggleFavorite,
 
-    onError: (error) => {
+    onMutate: async (id: number) => {
+      await cancelProblemListQueries();
+
+      const { favoriteData, nonFavoriteData } = getProblemListData();
+      const target = (nonFavoriteData?.pages ?? [])
+        .flatMap((p) => p.data)
+        .find((p) => p.id === id);
+      const fallbackTarget = queryClient.getQueryData<Problem>(
+        problemDetailKey(String(id)),
+      );
+
+      const resolvedTarget = target ?? fallbackTarget;
+      if (!resolvedTarget) return { favoriteData, nonFavoriteData };
+
+      const newFavoriteValue = !resolvedTarget.favorite;
+
+      updateProblemListCache(id, newFavoriteValue, resolvedTarget);
+      updateProblemDetailCache(id, newFavoriteValue);
+
+      return {
+        favoriteData,
+        nonFavoriteData,
+        newFavoriteValue,
+      };
+    },
+
+    onError: (error, _id, context) => {
+      restoreProblemListCache(context?.favoriteData, context?.nonFavoriteData);
       handleApiError(error);
     },
 
-    onSettled: () => {
-      queryClient.invalidateQueries({
-        queryKey: problemListKey({ favorite: true }),
-      });
-      queryClient.invalidateQueries({
-        queryKey: problemListKey({ favorite: false }),
-      });
+    onSuccess: (_data, id, context) => {
+      invalidateProblemList();
+      invalidateProblemDetail(String(id));
+
+      if (context?.newFavoriteValue) {
+        toast.success('즐겨찾기에 추가했어요.');
+      } else {
+        toast.success('즐겨찾기에서 제거했어요.');
+      }
     },
   });
+
+  return {
+    ...mutation,
+    toggle: (id: number) => {
+      if (!mutation.isPending) {
+        mutation.mutate(id);
+      }
+    },
+  };
 };

--- a/src/features/problems/api/use-upload-image.tsx
+++ b/src/features/problems/api/use-upload-image.tsx
@@ -34,7 +34,7 @@ export const useUploadImage = ({
   };
 
   return useMutation({
-    //mutationKey: ['imageUpload'],
+    mutationKey: ['imageUpload'],
     mutationFn: async (formData: FormData) => {
       const controller = new AbortController();
       handleUploadStart(controller);

--- a/src/features/problems/api/use-upload-image.tsx
+++ b/src/features/problems/api/use-upload-image.tsx
@@ -6,6 +6,7 @@ import { type NavigateFunction } from 'react-router-dom';
 import axios from 'axios';
 import { handleApiError } from '@/utils/handle-api-error';
 import { queryClient } from '@/lib/react-query';
+import { problemListKey } from '@/utils/query-key';
 
 type UseUploadImageProps = {
   setIsLoading: React.Dispatch<React.SetStateAction<boolean>>;
@@ -33,7 +34,7 @@ export const useUploadImage = ({
   };
 
   return useMutation({
-    mutationKey: ['imageUpload'],
+    //mutationKey: ['imageUpload'],
     mutationFn: async (formData: FormData) => {
       const controller = new AbortController();
       handleUploadStart(controller);
@@ -61,8 +62,12 @@ export const useUploadImage = ({
     },
     onMutate: () => {
       toast.info('현재 로딩중');
-      queryClient.invalidateQueries({ queryKey: ['problemList'] });
-      queryClient.invalidateQueries({ queryKey: ['problemDetail'] });
+      queryClient.invalidateQueries({
+        queryKey: problemListKey({ favorite: false }),
+      });
+      queryClient.invalidateQueries({
+        queryKey: problemListKey({ favorite: true }),
+      });
     },
   });
 

--- a/src/features/problems/detail/DetailFooter.tsx
+++ b/src/features/problems/detail/DetailFooter.tsx
@@ -3,6 +3,7 @@ import { Bookmark } from 'lucide-react';
 import { useDeleteProblem } from '../api/delete-problem';
 import { useNavigate } from 'react-router-dom';
 import { useModalStore } from '@/stores/modalStore';
+import { useToggleFavorite } from '../api/toggle-favorite';
 
 type DetailFooterProps = {
   id: string;
@@ -11,6 +12,8 @@ type DetailFooterProps = {
 
 export default function DetailFooter({ id, isFavorite }: DetailFooterProps) {
   const { mutate: deleteProblem, isPending: isDeleting } = useDeleteProblem();
+  const { toggle } = useToggleFavorite();
+
   const navigate = useNavigate();
   const openModal = useModalStore((state) => state.openModal);
 
@@ -26,6 +29,10 @@ export default function DetailFooter({ id, isFavorite }: DetailFooterProps) {
     openModal('DELETE_CONFIRM', { onConfirm: handleDelete });
   };
 
+  const handleFavoriteClick = () => {
+    toggle(Number(id));
+  };
+
   return (
     <footer
       className='w-full max-w-[var(--max-size-mobile)] pt-1 bg-background-light dark:bg-gray7 sticky bottom-0 flex justify-center items-center border-t border-gray2 dark:border-gray6'
@@ -39,6 +46,7 @@ export default function DetailFooter({ id, isFavorite }: DetailFooterProps) {
           variant='border'
           size='full'
           className='flex-1 text-md font-semibold'
+          onClick={handleFavoriteClick}
         >
           <Bookmark
             className='size-[20px]'

--- a/src/features/problems/list/GridView.tsx
+++ b/src/features/problems/list/GridView.tsx
@@ -4,7 +4,6 @@ import { Bookmark } from 'lucide-react';
 import { formatListDate } from '@/utils/date';
 import type { Problem } from '@/types/problem.type';
 import { useToggleFavorite } from '../api/toggle-favorite';
-import { useState } from 'react';
 
 type GridViewProps = {
   items: Problem[];

--- a/src/features/problems/list/GridView.tsx
+++ b/src/features/problems/list/GridView.tsx
@@ -3,49 +3,58 @@ import CardWrapper from '../components/CardWrapper';
 import { Bookmark } from 'lucide-react';
 import { formatListDate } from '@/utils/date';
 import type { Problem } from '@/types/problem.type';
+import { useToggleFavorite } from '../api/toggle-favorite';
+import { useState } from 'react';
 
 type GridViewProps = {
   items: Problem[];
 };
 
 export default function GridView({ items }: GridViewProps) {
-  const handleToggle = (e: React.MouseEvent) => {
+  const { toggle } = useToggleFavorite();
+
+  const handleToggle = (e: React.MouseEvent, id: number) => {
     e.preventDefault();
     e.stopPropagation();
-    console.log('즐겨찾기 토글');
+    toggle(id);
   };
+
   return (
     <div className='w-full flex justify-center flex-wrap gap-3'>
-      {items.map((item) => (
-        <Link
-          className='relative w-full'
-          to={`/problem/${item.id}`}
-          key={item.id}
-        >
-          <CardWrapper padding={false}>
-            <div className='w-full h-full flex flex-col gap-2 overflow-hidden'>
-              <button className='absolute top-0 left-2 p-2 cursor-pointer transition-transform hover:scale-115 active:scale-115 duration-300 ease-out'>
-                <Bookmark
-                  className=' text-primary '
-                  size={24}
-                  fill={item.favorite ? 'currentColor' : 'none'}
-                  onClick={handleToggle}
+      {items.map((item) => {
+        return (
+          <Link
+            className='relative w-full'
+            to={`/problem/${item.id}`}
+            key={item.id}
+          >
+            <CardWrapper padding={false}>
+              <div className='w-full h-full flex flex-col gap-2 overflow-hidden'>
+                <button
+                  onClick={(e) => handleToggle(e, item.id)}
+                  className='absolute top-0 left-2 p-2 cursor-pointer transition-transform hover:scale-115 active:scale-115 duration-300 ease-out'
+                >
+                  <Bookmark
+                    className=' text-primary '
+                    size={24}
+                    fill={item.favorite ? 'currentColor' : 'none'}
+                  />
+                </button>
+                <div className='flex justify-end'>
+                  <p className='label text-gray5 dark:text-gray2 pt-4 pr-4'>
+                    {formatListDate(item.activatedAt)}
+                  </p>
+                </div>
+                <img
+                  src={item.imageUrl}
+                  alt={Image.name}
+                  className='border-t border-gray1 dark:border-gray4 flex-1 object-contain h-full w-full'
                 />
-              </button>
-              <div className='flex justify-end'>
-                <p className='label text-gray5 dark:text-gray2 pt-4 pr-4'>
-                  {formatListDate(item.activatedAt)}
-                </p>
               </div>
-              <img
-                src={item.imageUrl}
-                alt={Image.name}
-                className='border-t border-gray1 dark:border-gray4 flex-1 object-contain h-full w-full'
-              />
-            </div>
-          </CardWrapper>
-        </Link>
-      ))}
+            </CardWrapper>
+          </Link>
+        );
+      })}
     </div>
   );
 }

--- a/src/features/problems/list/ListSection.tsx
+++ b/src/features/problems/list/ListSection.tsx
@@ -6,16 +6,16 @@ import { useProblemList } from '../api/get-problem-list';
 import { useRef } from 'react';
 import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
 import ListLoading from '@/components/ui/ListLoading';
+import { useFavoriteList } from '../api/get-favorite-list';
 
 export default function ListSection() {
   const [params] = useSearchParams();
 
-  // 즐겨찾기 API 연동 시 사용
-  //const favorite = params.get('favorite') === 'true';
+  const favorite = params.get('favorite') === 'true';
   const view = (params.get('view') as 'list' | 'grid') ?? 'list';
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPending } =
-    useProblemList();
+    favorite ? useFavoriteList() : useProblemList();
 
   const problems = data?.pages.flatMap((page) => page.data) ?? [];
   const targetRef = useRef<HTMLDivElement | null>(null);

--- a/src/features/problems/list/ListView.tsx
+++ b/src/features/problems/list/ListView.tsx
@@ -5,16 +5,19 @@ import { Bookmark } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import type React from 'react';
 import type { Problem } from '@/types/problem.type';
+import { useToggleFavorite } from '../api/toggle-favorite';
 
 type ListViewProps = {
   items: Problem[];
 };
 
 export default function ListView({ items }: ListViewProps) {
-  const handleToggle = (e: React.MouseEvent) => {
+  const { toggle } = useToggleFavorite();
+
+  const handleToggle = (e: React.MouseEvent, id: number) => {
     e.preventDefault();
     e.stopPropagation();
-    console.log('즐겨찾기 토글');
+    toggle(id);
   };
   return (
     <div className='w-full flex flex-col items-center gap-3'>
@@ -26,7 +29,7 @@ export default function ListView({ items }: ListViewProps) {
                 className='absolute left-0 text-primary'
                 size={30}
                 fill={item.favorite ? 'currentColor' : 'none'}
-                onClick={handleToggle}
+                onClick={(e) => handleToggle(e, item.id)}
               />
               <Title size='md'>{item.summary}</Title>
               <p className='body-sm text-gray5 dark:text-gray2 overflow-hidden text-ellipsis whitespace-nowrap'>

--- a/src/features/users/api/get-child-info.ts
+++ b/src/features/users/api/get-child-info.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { httpClient } from '@/lib/api-client';
 import type { Child } from '@/types/user.type';
+import { childInfoKey } from '@/utils/query-key';
 
 const getChildInfo = async (memberId: number) => {
   const res = await httpClient.get<Child>(`/member/${memberId}`);
@@ -9,7 +10,7 @@ const getChildInfo = async (memberId: number) => {
 
 export const useChildInfo = (memberId: number) => {
   return useQuery({
-    queryKey: ['child'],
+    queryKey: childInfoKey(),
     queryFn: () => getChildInfo(memberId),
   });
 };

--- a/src/features/users/api/update-child-info.ts
+++ b/src/features/users/api/update-child-info.ts
@@ -4,6 +4,7 @@ import { httpClient } from '@/lib/api-client';
 import { queryClient } from '@/lib/react-query';
 import type { Child, UpdateChildRequest } from '@/types/user.type';
 import { handleApiError } from '@/utils/handle-api-error';
+import { childInfoKey } from '@/utils/query-key';
 
 const updateChildInfo = async (memberId: number, data: UpdateChildRequest) => {
   const res = await httpClient.put(`/member/${memberId}`, data);
@@ -11,6 +12,8 @@ const updateChildInfo = async (memberId: number, data: UpdateChildRequest) => {
 };
 
 export const useUpdateChildInfo = () => {
+  const queryKey = childInfoKey();
+
   return useMutation({
     mutationFn: ({
       memberId,
@@ -21,11 +24,11 @@ export const useUpdateChildInfo = () => {
     }) => updateChildInfo(memberId, data),
 
     onMutate: async ({ memberId: _memberId, data }) => {
-      await queryClient.cancelQueries({ queryKey: ['child'] });
+      await queryClient.cancelQueries({ queryKey });
 
-      const prevData = queryClient.getQueryData<Child>(['child']);
+      const prevData = queryClient.getQueryData<Child>(queryKey);
 
-      queryClient.setQueryData(['child'], (old: any) => {
+      queryClient.setQueryData(queryKey, (old: any) => {
         if (!old) return old;
 
         return {
@@ -44,14 +47,14 @@ export const useUpdateChildInfo = () => {
 
     onError: (error, _variables, context) => {
       if (context?.prevData) {
-        queryClient.setQueryData(['child'], context.prevData);
+        queryClient.setQueryData(queryKey, context.prevData);
       }
       handleApiError(error);
     },
 
     onSettled: () => {
       queryClient.invalidateQueries({
-        queryKey: ['child'],
+        queryKey,
       });
     },
   });

--- a/src/features/users/my-page/ChildrenListSection.tsx
+++ b/src/features/users/my-page/ChildrenListSection.tsx
@@ -4,6 +4,7 @@ import { handleApiError } from '@/utils/handle-api-error';
 import axios from 'axios';
 import ListLoading from '@/components/ui/ListLoading';
 import { useNavigate } from 'react-router-dom';
+import { useEffect } from 'react';
 
 const concepts = [
   { id: 1, name: '분수' },
@@ -14,24 +15,26 @@ export default function ChildrenListSection() {
   const { data, isPending, isError, error } = useChildInfo(8);
   const navigate = useNavigate();
 
-  if (isError) {
-    handleApiError(error);
+  useEffect(() => {
+    if (isError) {
+      handleApiError(error);
+      const status = axios.isAxiosError(error) ? error.response?.status : null;
 
-    const status = axios.isAxiosError(error) ? error.response?.status : null;
-    if (status === 403 || status === 404)
-      navigate('/not-found', {
-        state: { from: 'api-error' },
-      });
-    else
-      navigate('/error', {
-        state: { from: 'api-error' },
-      });
+      if (status === 403 || status === 404)
+        navigate('/not-found', {
+          state: { from: 'api-error' },
+        });
+      else
+        navigate('/error', {
+          state: { from: 'api-error' },
+        });
+    }
+  }, [isError, error, navigate]);
 
-    return null;
-  }
-
-  if (isPending)
+  if (isPending) {
     return <ListLoading description='아이 정보를 불러오고 있어요...' />;
+  }
+  if (isError) return null;
 
   return (
     <section className='flex flex-col items-center gap-4'>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,5 +13,5 @@ createRoot(document.getElementById('root')!).render(
       <App />
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
-  </StrictMode>
+  </StrictMode>,
 );

--- a/src/pages/ProblemDetailPage.tsx
+++ b/src/pages/ProblemDetailPage.tsx
@@ -1,4 +1,4 @@
-import axios, { AxiosError } from 'axios';
+import axios from 'axios';
 import { useNavigate, useParams } from 'react-router-dom';
 import Markdown from 'react-markdown';
 import remarkMath from 'remark-math';
@@ -41,7 +41,7 @@ export default function ProblemDetailPage() {
   }, [isError, error, navigate]);
 
   if (isPending) return <Loading />;
-  if (isError) return null;
+  if (isError || !data) return null;
 
   return (
     <section className='w-full h-full flex flex-col'>

--- a/src/pages/ProblemDetailPage.tsx
+++ b/src/pages/ProblemDetailPage.tsx
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 import { useNavigate, useParams } from 'react-router-dom';
 import Markdown from 'react-markdown';
 import remarkMath from 'remark-math';
@@ -16,7 +16,7 @@ import Loading from '@/components/ui/Loading';
 import { formatDetailDate } from '@/utils/date';
 import { useProblemDetail } from '@/features/problems/api/get-problem-detail';
 import { handleApiError } from '@/utils/handle-api-error';
-import { sanitizeMathMarkdown } from '@/utils/sanitize-math-markdown';
+import { useEffect } from 'react';
 
 export default function ProblemDetailPage() {
   const { _id } = useParams();
@@ -24,23 +24,24 @@ export default function ProblemDetailPage() {
 
   const { data, isPending, isError, error } = useProblemDetail(_id!);
 
-  if (isError) {
-    handleApiError(error);
+  useEffect(() => {
+    if (isError) {
+      handleApiError(error);
+      const status = axios.isAxiosError(error) ? error.response?.status : null;
 
-    const status = axios.isAxiosError(error) ? error.response?.status : null;
-    if (status === 403 || status === 404)
-      navigate('/not-found', {
-        state: { from: 'api-error' },
-      });
-    else
-      navigate('/error', {
-        state: { from: 'api-error' },
-      });
-
-    return null;
-  }
+      if (status === 403 || status === 404)
+        navigate('/not-found', {
+          state: { from: 'api-error' },
+        });
+      else
+        navigate('/error', {
+          state: { from: 'api-error' },
+        });
+    }
+  }, [isError, error, navigate]);
 
   if (isPending) return <Loading />;
+  if (isError) return null;
 
   return (
     <section className='w-full h-full flex flex-col'>
@@ -81,7 +82,7 @@ export default function ProblemDetailPage() {
               remarkPlugins={[remarkMath, remarkGfm]}
               rehypePlugins={[rehypeKatex]}
             >
-              {sanitizeMathMarkdown(data.explanation)}
+              {data.explanation}
             </Markdown>
           </CardWrapper>
         </DetailSection>

--- a/src/pages/ProblemDetailPage.tsx
+++ b/src/pages/ProblemDetailPage.tsx
@@ -16,10 +16,7 @@ import Loading from '@/components/ui/Loading';
 import { formatDetailDate } from '@/utils/date';
 import { useProblemDetail } from '@/features/problems/api/get-problem-detail';
 import { handleApiError } from '@/utils/handle-api-error';
-
-function sanitizeMathMarkdown(input: string) {
-  return JSON.stringify(input).slice(1, -1);
-}
+import { sanitizeMathMarkdown } from '@/utils/sanitize-math-markdown';
 
 export default function ProblemDetailPage() {
   const { _id } = useParams();

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -34,10 +34,9 @@ const router = createBrowserRouter([
         index: true,
         element: (
           <BasicLayout>
-            {/* <RequireAuth>
+            <RequireAuth>
               <HomePage />
-            </RequireAuth> */}
-            <HomePage />
+            </RequireAuth>
           </BasicLayout>
         ),
       },
@@ -86,11 +85,9 @@ const router = createBrowserRouter([
         path: '/history',
         element: (
           <BasicLayout>
-            <ProblemHistoryPage />
-
-            {/* <RequireAuth>
+            <RequireAuth>
               <ProblemHistoryPage />
-            </RequireAuth> */}
+            </RequireAuth>
           </BasicLayout>
         ),
       },
@@ -98,20 +95,18 @@ const router = createBrowserRouter([
         path: '/profile',
         element: (
           <BasicLayout>
-            {/* <RequireAuth>
+            <RequireAuth>
               <MyPage />
-            </RequireAuth> */}
-            <MyPage />
+            </RequireAuth>
           </BasicLayout>
         ),
       },
       {
         path: '/problem',
         element: (
-          // <RequireAuth>
-          //   <Outlet />
-          // </RequireAuth>
-          <Outlet />
+          <RequireAuth>
+            <Outlet />
+          </RequireAuth>
         ),
         children: [
           {

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -34,9 +34,10 @@ const router = createBrowserRouter([
         index: true,
         element: (
           <BasicLayout>
-            <RequireAuth>
+            {/* <RequireAuth>
               <HomePage />
-            </RequireAuth>
+            </RequireAuth> */}
+            <HomePage />
           </BasicLayout>
         ),
       },
@@ -85,9 +86,11 @@ const router = createBrowserRouter([
         path: '/history',
         element: (
           <BasicLayout>
-            <RequireAuth>
+            <ProblemHistoryPage />
+
+            {/* <RequireAuth>
               <ProblemHistoryPage />
-            </RequireAuth>
+            </RequireAuth> */}
           </BasicLayout>
         ),
       },
@@ -95,18 +98,20 @@ const router = createBrowserRouter([
         path: '/profile',
         element: (
           <BasicLayout>
-            <RequireAuth>
+            {/* <RequireAuth>
               <MyPage />
-            </RequireAuth>
+            </RequireAuth> */}
+            <MyPage />
           </BasicLayout>
         ),
       },
       {
         path: '/problem',
         element: (
-          <RequireAuth>
-            <Outlet />
-          </RequireAuth>
+          // <RequireAuth>
+          //   <Outlet />
+          // </RequireAuth>
+          <Outlet />
         ),
         children: [
           {

--- a/src/types/modal.type.ts
+++ b/src/types/modal.type.ts
@@ -5,7 +5,7 @@ export interface BaseModalProps {
 }
 
 export type ModalPropsMap = {
-  CONCEPT: { title: string; description: string };
+  CONCEPT: { id: number; title: string };
   DELETE_CONFIRM: {
     onConfirm: () => void;
   };

--- a/src/types/problem.type.ts
+++ b/src/types/problem.type.ts
@@ -27,3 +27,16 @@ export type GetProblemListResponse = {
 export type CursorPaginationParams = {
   pageParam?: string | null;
 };
+
+export type GetFavoriteListResponse = {
+  data: (Problem & { problemId: number })[];
+  pagination: {
+    limit: number;
+    hasNextPage: boolean;
+    nextCursor: string;
+  };
+  links: {
+    self: string;
+    next: string;
+  };
+};

--- a/src/utils/handle-api-error.ts
+++ b/src/utils/handle-api-error.ts
@@ -18,7 +18,7 @@ export function handleApiError(error: unknown) {
       window.location.href = '/intro';
     }, 1500);
   } else if (status === 404) {
-    toast.error('데이터를 찾을 수 없습니다.');
+    toast.error(message || '데이터를 찾을 수 없습니다.');
   } else if (status && status >= 500) {
     toast.error('일시적인 서버 오류가 발생했어요.');
   } else {

--- a/src/utils/query-key.ts
+++ b/src/utils/query-key.ts
@@ -5,7 +5,10 @@ type ProblemListParams = {
 export const problemListKey = (params: ProblemListParams) =>
   ['problemList', params] as const;
 
-export const problemDetailKey = (problemId: string | string) =>
+export const problemDetailKey = (problemId: string) =>
   ['problemDetail', problemId] as const;
 
 export const childInfoKey = () => ['child'] as const;
+
+export const conceptKey = (conceptId: string) =>
+  ['concept', conceptId] as const;

--- a/src/utils/query-key.ts
+++ b/src/utils/query-key.ts
@@ -1,0 +1,11 @@
+type ProblemListParams = {
+  favorite: boolean;
+};
+
+export const problemListKey = (params: ProblemListParams) =>
+  ['problemList', params] as const;
+
+export const problemDetailKey = (problemId: string | string) =>
+  ['problemDetail', problemId] as const;
+
+export const childInfoKey = () => ['child'] as const;

--- a/src/utils/sanitize-math-markdown.ts
+++ b/src/utils/sanitize-math-markdown.ts
@@ -1,0 +1,4 @@
+export const sanitizeMathMarkdown = (input: string) => {
+  const escaped = JSON.stringify(input).slice(1, -1);
+  return escaped.replace(/\\n/g, '\n');
+};

--- a/src/utils/sanitize-math-markdown.ts
+++ b/src/utils/sanitize-math-markdown.ts
@@ -1,4 +1,0 @@
-export const sanitizeMathMarkdown = (input: string) => {
-  const escaped = JSON.stringify(input).slice(1, -1);
-  return escaped.replace(/\\n/g, '\n');
-};


### PR DESCRIPTION
## PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [x] 파일 혹은 폴더 삭제

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## PR 상세
### queryKey 유틸 함수 분리
- 기존 useQuery, useInfiniteQuery 등에서 직접 문자열로 작성하던 쿼리 키를 유틸 함수로 분리

- 중복 제거 및 유지 보수성 향상을 위함

### 즐겨찾기 관련 API 연동
#### 쿼리키 변경
- 전체 목록 쿼리 키 : `['problemList']`에서 `['problemList', { favorite : false}]`로 변경
- 
- 즐겨찾기 목록 쿼리 키: `['problemList', { favorite : true}]` 사용

#### 즐겨찾기 목록 조회 API 연동
- 해설 목록 페이지에서 즐겨찾기 탭 선택 시 즐겨찾기 데이터만 무한 스크롤 형태로 조회 가능

#### 즐겨찾기 토글 API 연동
- 낙관적 업데이트 적용
  - 버튼 클릭 시 바로 UI에 반영
  - 실패 시 이전 상태로 복구 + 토스트 메시지 보여줌
  - 성공 시 서버와 동기화 위해 관련 쿼리 무효화

- 캐시 조작 함수 설명
  - `cancelProblemListQueries` : 즐겨찾기/전체 목록 쿼리 취소
  - `getProblemListData` : 해설 목록 캐시 데이터 가져오기
  - `updateProblemListCache` : 즐겨찾기 여부에 따라 목록 캐시 추가/제거
  - `updateProblemDetailCache` : 상세 페이지 캐시 업데이트
  - `restoreProblemListCache` : 이전 상태로 롤백(실패 시 사용)
  - `invalidateProblemList`, `invalidateProblemDetail` : 캐시 동기화를 위한 쿼리 무효화
 
### 개념 조회 API 연동
- 개념(해시태그) 클릭 시 설명을 모달을 통해 렌더링
- `description` 필드가 null인 경우 '곧 개념에 대한 설명이 추가될 예정이에요.' 문구로 대체


https://github.com/user-attachments/assets/813e24e4-e302-4cb1-a9fd-1f25cf32b5b0

https://github.com/user-attachments/assets/55931c6b-8efb-47e2-a5a3-ae19c904abc1


