### PR TITLE
[AMT-110] 이미지 업로드 요청 중 뒤로가기 로직 리팩토링

### DIFF
--- a/src/features/problems/api/use-upload-image.tsx
+++ b/src/features/problems/api/use-upload-image.tsx
@@ -11,25 +11,21 @@ import { problemListKey } from '@/utils/query-key';
 type UseUploadImageProps = {
   setIsLoading: React.Dispatch<React.SetStateAction<boolean>>;
   controllerRef: React.RefObject<AbortController | null>;
-  isLoadingRef: React.RefObject<boolean>;
   navigate: NavigateFunction;
 };
 
 export const useUploadImage = ({
   setIsLoading,
   controllerRef,
-  isLoadingRef,
   navigate,
 }: UseUploadImageProps) => {
   const handleUploadStart = (controller: AbortController) => {
     controllerRef.current = controller;
-    isLoadingRef.current = true;
     setIsLoading(true);
   };
 
   const handleUploadEnd = () => {
     controllerRef.current = null;
-    isLoadingRef.current = false;
     setIsLoading(false);
   };
 
@@ -44,7 +40,7 @@ export const useUploadImage = ({
       return res;
     },
     onError: (err: AxiosError) => {
-      handleUploadEnd();
+      controllerRef.current = null;
       if (axios.isCancel(err)) {
         toast.error('요청을 취소하셨습니다.');
       } else {
@@ -69,25 +65,4 @@ export const useUploadImage = ({
       });
     },
   });
-
-  // const getCroppedData = (
-  //   cropper: Cropper | undefined,
-  //   setImage: React.Dispatch<React.SetStateAction<string | undefined>>,
-  // ) => {
-  //   if (cropper) {
-  //     const croppedImage = cropper.getCroppedCanvas().toDataURL();
-  //     setImage(croppedImage);
-  //     const formData = new FormData();
-  //     cropper.getCroppedCanvas().toBlob((blob) => {
-  //       if (!blob) return;
-  //       const randomName = `image_${Date.now()}_${Math.random().toString(36).substring(2, 8)}.png`;
-  //       const file = new File([blob], randomName, { type: 'image/png' });
-  //       if (blob) formData.append('file', file);
-
-  //       mutate(formData);
-  //     });
-  //   }
-  // };
-
-  // return { getCroppedData };
 };

--- a/src/features/problems/api/use-upload-image.tsx
+++ b/src/features/problems/api/use-upload-image.tsx
@@ -40,10 +40,11 @@ export const useUploadImage = ({
       return res;
     },
     onError: (err: AxiosError) => {
-      controllerRef.current = null;
       if (axios.isCancel(err)) {
+        controllerRef.current = null;
         toast.error('요청을 취소하셨습니다.');
       } else {
+        handleUploadEnd();
         handleApiError(err);
       }
     },

--- a/src/features/problems/components/ProblemUploadLoading.tsx
+++ b/src/features/problems/components/ProblemUploadLoading.tsx
@@ -10,10 +10,16 @@ type StepData = {
   content: string;
 };
 
+type ProblemUploadLoadingProps = {
+  onBackClick?: () => void;
+};
+
 const DEFAULT_ANIMATION_DELAY = 0.1;
 const STEP_DISPLAY_TIME = 5000;
 
-export default function ProblemUploadLoading() {
+export default function ProblemUploadLoading({
+  onBackClick,
+}: ProblemUploadLoadingProps) {
   const [currentStep, setCurrentStep] = useState<number>(0);
 
   const steps: StepData[] = [
@@ -52,7 +58,7 @@ export default function ProblemUploadLoading() {
 
   return (
     <div className='w-full h-full flex flex-col'>
-      <SubHeader type='back' title='' />
+      <SubHeader type='back' title='' onBackClick={onBackClick} />
 
       <div className='flex-1 flex flex-col items-center justify-center text-center h-full -mt-30'>
         <div className='flex flex-col items-center justify-center gap-4 w-full max-w-md space-y-8'>

--- a/src/features/problems/components/ProblemUploadLoading.tsx
+++ b/src/features/problems/components/ProblemUploadLoading.tsx
@@ -10,16 +10,10 @@ type StepData = {
   content: string;
 };
 
-type ProblemUploadLoadingProps = {
-  onBackClick?: () => void;
-};
-
 const DEFAULT_ANIMATION_DELAY = 0.1;
 const STEP_DISPLAY_TIME = 5000;
 
-export default function ProblemUploadLoading({
-  onBackClick,
-}: ProblemUploadLoadingProps) {
+export default function ProblemUploadLoading() {
   const [currentStep, setCurrentStep] = useState<number>(0);
 
   const steps: StepData[] = [
@@ -58,7 +52,7 @@ export default function ProblemUploadLoading({
 
   return (
     <div className='w-full h-full flex flex-col'>
-      <SubHeader type='back' title='' onBackClick={onBackClick} />
+      <SubHeader type='back' title='' />
 
       <div className='flex-1 flex flex-col items-center justify-center text-center h-full -mt-30'>
         <div className='flex flex-col items-center justify-center gap-4 w-full max-w-md space-y-8'>

--- a/src/pages/ProblemUploadPage.tsx
+++ b/src/pages/ProblemUploadPage.tsx
@@ -17,7 +17,7 @@ const NAVIGATION_DELAY = 0;
 export default function ProblemUploadPage() {
   const navigate = useNavigate();
 
-  const imageFile = useImageStore((state: imageStore) => state.imageUrl);
+  const { imageUrl, setImageFile } = useImageStore();
 
   const [image, setImage] = useState<string | undefined>();
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -25,15 +25,12 @@ export default function ProblemUploadPage() {
   const cropperRef = useRef<ReactCropperElement>(null);
   const uploadRef = useRef<HTMLInputElement>(null);
   const controllerRef = useRef<AbortController | null>(null);
-  const isLoadingRef = useRef(false);
-  const isHandlingPopRef = useRef(false);
 
   const cropper = cropperRef.current?.cropper;
 
   const { mutate } = useUploadImage({
     setIsLoading,
     controllerRef,
-    isLoadingRef,
     navigate,
   });
 
@@ -41,50 +38,33 @@ export default function ProblemUploadPage() {
     uploadRef.current?.click();
   };
 
+  const preventGoBack = () => {
+    if (
+      confirm(
+        '뒤로 가면 해설이 생성되지 않을 수 있어요.\n정말 뒤로 가시겠어요?',
+      )
+    ) {
+      navigate('/');
+      controllerRef.current?.abort();
+      setImageFile(undefined);
+    }
+  };
+
   useEffect(() => {
-    if (imageFile) {
-      setImage(imageFile);
-    } else if (imageFile === undefined) {
+    if (isLoading) return;
+
+    if (imageUrl) {
+      setImage(imageUrl);
+    } else if (imageUrl === undefined) {
       setTimeout(() => {
         navigate('/');
-        toast.error('유효하지 않은 접근이 감지되어 홈으로 이동합니다.');
+        toast.error('홈 화면에서 문제 사진을 등록해주세요.');
       }, NAVIGATION_DELAY);
     }
-  }, [imageFile, navigate]);
-
-  useEffect(() => {
-    window.history.pushState({ preventBack: true }, '', location.href);
-
-    const onPopState = () => {
-      if (!isLoadingRef.current || isHandlingPopRef.current) return;
-
-      isHandlingPopRef.current = true; // ✅ confirm 중복 방지
-
-      const check = confirm(
-        '사이트 이탈 시 변경사항이 저장되지 않습니다. 정말 나가시겠습니까?',
-      );
-
-      if (check) {
-        controllerRef.current?.abort();
-        navigate('/', { replace: true });
-      } else {
-        // ❗ forward() 후 다시 popstate가 뜨지 않도록 잠깐 막기
-        setTimeout(() => {
-          isHandlingPopRef.current = false;
-        }, 100); // 브라우저 forward 타이밍보다 살짝 늦게
-        window.history.forward();
-      }
-    };
-
-    window.addEventListener('popstate', onPopState);
-
-    return () => {
-      window.removeEventListener('popstate', onPopState);
-    };
-  }, []);
+  }, [imageUrl, navigate]);
 
   if (isLoading) {
-    return <ProblemUploadLoading />;
+    return <ProblemUploadLoading onBackClick={preventGoBack} />;
   }
 
   return (

--- a/src/pages/ProblemUploadPage.tsx
+++ b/src/pages/ProblemUploadPage.tsx
@@ -2,7 +2,7 @@ import SubHeader from '@/components/layout/SubHeader';
 import { Button } from '@/components/ui/button';
 import ImageCropper from '@/features/problems/components/ImageCropper';
 import ImageUpload from '@/features/problems/components/ImageUploadInput';
-import useImageStore, { type imageStore } from '@/stores/imageStore';
+import useImageStore from '@/stores/imageStore';
 import { Info } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import type { ReactCropperElement } from 'react-cropper';
@@ -38,7 +38,7 @@ export default function ProblemUploadPage() {
     uploadRef.current?.click();
   };
 
-  const preventGoBack = () => {
+  const handleBackClick = () => {
     if (
       confirm(
         '뒤로 가면 해설이 생성되지 않을 수 있어요.\n정말 뒤로 가시겠어요?',
@@ -64,7 +64,7 @@ export default function ProblemUploadPage() {
   }, [imageUrl, navigate]);
 
   if (isLoading) {
-    return <ProblemUploadLoading onBackClick={preventGoBack} />;
+    return <ProblemUploadLoading onBackClick={handleBackClick} />;
   }
 
   return (

--- a/src/pages/ProblemUploadPage.tsx
+++ b/src/pages/ProblemUploadPage.tsx
@@ -6,7 +6,7 @@ import useImageStore from '@/stores/imageStore';
 import { Info } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import type { ReactCropperElement } from 'react-cropper';
-import { useNavigate } from 'react-router-dom';
+import { useBlocker, useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 import ProblemUploadLoading from '../features/problems/components/ProblemUploadLoading';
 import getCroppedData from '@/features/problems/api/get-cropped-data';
@@ -21,12 +21,34 @@ export default function ProblemUploadPage() {
 
   const [image, setImage] = useState<string | undefined>();
   const [isLoading, setIsLoading] = useState<boolean>(false);
-
   const cropperRef = useRef<ReactCropperElement>(null);
   const uploadRef = useRef<HTMLInputElement>(null);
   const controllerRef = useRef<AbortController | null>(null);
 
   const cropper = cropperRef.current?.cropper;
+
+  const confirmLeave = () => {
+    if (
+      confirm(
+        '뒤로 가면 해설이 생성되지 않을 수 있어요.\n정말 뒤로 가시겠어요?',
+      )
+    ) {
+      controllerRef.current?.abort();
+      setImageFile(undefined);
+      return true;
+    }
+    return false;
+  };
+
+  const blocker = useBlocker(
+    ({ currentLocation, nextLocation, historyAction }) => {
+      return (
+        isLoading &&
+        historyAction === 'POP' &&
+        currentLocation.pathname !== nextLocation.pathname
+      );
+    },
+  );
 
   const { mutate } = useUploadImage({
     setIsLoading,
@@ -36,18 +58,6 @@ export default function ProblemUploadPage() {
 
   const handleReupload = () => {
     uploadRef.current?.click();
-  };
-
-  const handleBackClick = () => {
-    if (
-      confirm(
-        '뒤로 가면 해설이 생성되지 않을 수 있어요.\n정말 뒤로 가시겠어요?',
-      )
-    ) {
-      navigate('/');
-      controllerRef.current?.abort();
-      setImageFile(undefined);
-    }
   };
 
   useEffect(() => {
@@ -63,17 +73,23 @@ export default function ProblemUploadPage() {
     }
   }, [imageUrl, navigate]);
 
+  useEffect(() => {
+    if (blocker.state === 'blocked') {
+      if (confirmLeave()) {
+        blocker.proceed();
+      } else {
+        blocker.reset();
+      }
+    }
+  }, [blocker.state]);
+
   if (isLoading) {
-    return <ProblemUploadLoading onBackClick={handleBackClick} />;
+    return <ProblemUploadLoading />;
   }
 
   return (
     <section className='flex flex-1 flex-col w-full h-full'>
-      <SubHeader
-        type='close'
-        title='문제 등록하기'
-        onBackClick={() => navigate('/')}
-      />
+      <SubHeader type='close' title='문제 등록하기' />
       <section className='flex flex-1 flex-col w-full h-fit pb-10'>
         <div className='mt-16 mb-[15px] ml-[15px] flex flex-row'>
           <Info size={16} className='text-primary mt-[4px] mr-[10px]' />


### PR DESCRIPTION
## PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## PR 상세
### 이미지 업로드 로딩 중 뒤로가기 로직 재수정 - useBlocker 적용
#### 기존
- popstate 이벤트 핸들러에서 브라우저 히스토리를 수동으로 조작
- 히스토리 조작 과정에서 히스토리가 꼬이는 문제 발생 가능성

#### 1차 수정 (홈 리다이렉트 방식)
- 뒤로가기 처리 방식 변경: 뒤로가기 버튼 클릭 시 홈으로 리다이렉트
- 이미지 데이터 정리: imageStore에 저장된 이미지 삭제
- 토스트 메시지 개선: 중복 토스트 방지를 위한 `isLoading` state 조건 검사 추가
- 코드 정리: 불필요한 변수(`isLoadingRef`) 제거

#### 1차 수정 문제점
- 브라우저 자체 뒤로가기는 대응할 수 없음

#### 2차 수정 (useBlocker로 통합 처리)
- 브라우저 뒤로가기 & 뒤로가기 버튼 처리 방식 변경: useBlocker를 활용하여 로딩 중 브라우저 뒤로가기 시 확인창 표시


https://github.com/user-attachments/assets/35f90048-bd7d-4048-8823-596c89ddc09c





