### PR TITLE
[AMT-118] 즐겨찾기 토글 로직 개선

### DIFF
--- a/src/features/problems/api/get-problem-detail.ts
+++ b/src/features/problems/api/get-problem-detail.ts
@@ -3,12 +3,12 @@ import { httpClient } from '@/lib/api-client';
 import { type Problem } from '@/types/problem.type';
 import { problemDetailKey } from '@/utils/query-key';
 
-const getProblemDetail = async (id: string) => {
+const getProblemDetail = async (id: number) => {
   const res = await httpClient.get<Problem>(`/problem?problemId=${id}`);
   return res.data;
 };
 
-export const useProblemDetail = (id: string) => {
+export const useProblemDetail = (id: number) => {
   return useQuery({
     queryKey: problemDetailKey(id),
     queryFn: () => getProblemDetail(id),

--- a/src/features/problems/api/toggle-favorite.ts
+++ b/src/features/problems/api/toggle-favorite.ts
@@ -1,166 +1,133 @@
-import { useMutation } from '@tanstack/react-query';
+import {
+  useMutation,
+  type InfiniteData,
+  type QueryKey,
+} from '@tanstack/react-query';
 import { queryClient } from '@/lib/react-query';
 import { httpClient } from '@/lib/api-client';
 import { handleApiError } from '@/utils/handle-api-error';
 import { problemDetailKey, problemListKey } from '@/utils/query-key';
 import {
+  type ToggleFavoriteResponse,
   type GetProblemListResponse,
   type Problem,
+  type FavoriteToggleSource,
+  type CursorPaginationParams,
 } from '@/types/problem.type';
 import { toast } from 'sonner';
 
 // API 호출 함수
 const toggleFavorite = async (id: number) => {
-  const res = await httpClient.post(`/favorite?problemId=${id}`);
+  const res = await httpClient.post<ToggleFavoriteResponse>(
+    `/favorite?problemId=${id}`,
+  );
   return res.data;
 };
 
-// cache 핸들링 함수 모음
-const cancelProblemListQueries = async () => {
-  await queryClient.cancelQueries({
-    queryKey: problemListKey({ favorite: true }),
-  });
-  await queryClient.cancelQueries({
-    queryKey: problemListKey({ favorite: false }),
-  });
-};
-
-const getProblemListData = () => {
-  const favoriteData = queryClient.getQueryData<{
-    pages: GetProblemListResponse[];
-    pageParams: any[];
-  }>(problemListKey({ favorite: true }));
-
-  const nonFavoriteData = queryClient.getQueryData<{
-    pages: GetProblemListResponse[];
-    pageParams: any[];
-  }>(problemListKey({ favorite: false }));
-
-  return { favoriteData, nonFavoriteData };
-};
-
-const updateProblemListCache = (
+const updateListQuery = (
+  key: QueryKey,
   id: number,
-  newFavoriteValue: boolean,
-  target: GetProblemListResponse['data'][number],
+  updateFn: (p: Problem[]) => Problem[],
 ) => {
-  const favoriteKey = problemListKey({ favorite: true });
-  const nonFavoriteKey = problemListKey({ favorite: false });
-
-  queryClient.setQueryData(nonFavoriteKey, (old: any) => {
-    if (!old) return old;
-    return {
-      ...old,
-      pages: old.pages.map((page: GetProblemListResponse) => ({
-        ...page,
-        data: page.data.map((problem) =>
-          problem.id === id
-            ? { ...problem, favorite: newFavoriteValue }
-            : problem,
-        ),
-      })),
-    };
-  });
-
-  queryClient.setQueryData(favoriteKey, (old: any) => {
-    if (!old) return old;
-    return {
-      ...old,
-      pages: old.pages.map((page: GetProblemListResponse, idx: number) => {
-        if (newFavoriteValue && idx === 0) {
-          return {
-            ...page,
-            data: [{ ...target, favorite: true }, ...page.data],
-          };
-        } else {
-          return {
-            ...page,
-            data: page.data.filter((problem) => problem.id !== id),
-          };
-        }
-      }),
-    };
-  });
-};
-
-const updateProblemDetailCache = (id: number, newFavoriteValue: boolean) => {
-  queryClient.setQueryData(problemDetailKey(String(id)), (old: any) => {
-    if (!old) return old;
-    return { ...old, favorite: newFavoriteValue };
-  });
-};
-
-const restoreProblemListCache = (
-  favoriteData?: unknown,
-  nonFavoriteData?: unknown,
-) => {
-  queryClient.setQueryData(problemListKey({ favorite: true }), favoriteData);
   queryClient.setQueryData(
-    problemListKey({ favorite: false }),
-    nonFavoriteData,
+    key,
+    (prev: InfiniteData<GetProblemListResponse, CursorPaginationParams>) => {
+      if (!prev?.pages?.length) return prev;
+      const pages = [...prev.pages];
+      const idx = pages.findIndex((page) =>
+        page.data.some((problem) => problem.id === id),
+      );
+
+      if (idx < 0) return prev;
+
+      const page = pages[idx];
+      const updated = updateFn(page.data);
+
+      pages[idx] = { ...page, data: updated };
+      return { ...prev, pages };
+    },
   );
 };
 
-const invalidateProblemList = () => {
-  queryClient.invalidateQueries({
-    queryKey: problemListKey({ favorite: true }),
-  });
-  queryClient.invalidateQueries({
-    queryKey: problemListKey({ favorite: false }),
-  });
-};
-
-const invalidateProblemDetail = (id: string) => {
-  queryClient.invalidateQueries({
-    queryKey: problemDetailKey(id),
-  });
-};
-
 // toggle 훅
-export const useToggleFavorite = () => {
+export const useToggleFavorite = (source: FavoriteToggleSource) => {
   const mutation = useMutation({
     mutationFn: toggleFavorite,
 
     onMutate: async (id: number) => {
-      await cancelProblemListQueries();
+      const detailKey = problemDetailKey(id);
+      const listKey = problemListKey({ favorite: false });
+      const favoriteKey = problemListKey({ favorite: true });
+      let prevData;
 
-      const { favoriteData, nonFavoriteData } = getProblemListData();
-      const target = (nonFavoriteData?.pages ?? [])
-        .flatMap((p) => p.data)
-        .find((p) => p.id === id);
-      const fallbackTarget = queryClient.getQueryData<Problem>(
-        problemDetailKey(String(id)),
-      );
+      if (source === 'detail') {
+        await queryClient.cancelQueries({ queryKey: detailKey, exact: true });
+        prevData = queryClient.getQueryData(detailKey);
+        queryClient.setQueryData(detailKey, (prev: Problem) =>
+          prev ? { ...prev, favorite: !prev.favorite } : prev,
+        );
+      }
 
-      const resolvedTarget = target ?? fallbackTarget;
-      if (!resolvedTarget) return { favoriteData, nonFavoriteData };
+      if (source === 'list') {
+        await queryClient.cancelQueries({ queryKey: listKey, exact: true });
+        prevData = queryClient.getQueryData(listKey);
+        updateListQuery(listKey, id, (data) =>
+          data.map((problem) =>
+            problem.id === id
+              ? { ...problem, favorite: !problem.favorite }
+              : problem,
+          ),
+        );
+      }
 
-      const newFavoriteValue = !resolvedTarget.favorite;
-
-      updateProblemListCache(id, newFavoriteValue, resolvedTarget);
-      updateProblemDetailCache(id, newFavoriteValue);
+      if (source === 'favorite') {
+        await queryClient.cancelQueries({ queryKey: favoriteKey, exact: true });
+        prevData = queryClient.getQueryData(favoriteKey);
+        updateListQuery(favoriteKey, id, (data) =>
+          data.filter((problem) => problem.id !== id),
+        );
+      }
 
       return {
-        favoriteData,
-        nonFavoriteData,
-        newFavoriteValue,
+        prevData,
+        detailKey,
+        listKey,
+        favoriteKey,
+        rollbackKey:
+          source === 'detail'
+            ? detailKey
+            : source === 'favorite'
+              ? favoriteKey
+              : listKey,
       };
     },
 
     onError: (error, _id, context) => {
-      restoreProblemListCache(context?.favoriteData, context?.nonFavoriteData);
+      queryClient.setQueryData(context?.rollbackKey!, context?.prevData);
       handleApiError(error);
     },
 
-    onSuccess: (_data, id, context) => {
-      invalidateProblemList();
-      invalidateProblemDetail(String(id));
+    onSuccess: (data, id, context) => {
+      const favorited = data.favorited;
 
-      if (context?.newFavoriteValue) {
-        toast.success('즐겨찾기에 추가했어요.');
-      } else {
-        toast.success('즐겨찾기에서 제거했어요.');
-      }
+      queryClient.invalidateQueries({
+        queryKey: problemListKey({ favorite: true }),
+        exact: true,
+      });
+
+      queryClient.setQueryData(context.detailKey, (prev: Problem) =>
+        prev ? { ...prev, favorite: favorited } : prev,
+      );
+
+      updateListQuery(context.listKey, id, (data) =>
+        data.map((problem) =>
+          problem.id === id ? { ...problem, favorite: favorited } : problem,
+        ),
+      );
+
+      toast.success(
+        favorited ? '즐겨찾기에 추가했어요.' : '즐겨찾기에서 제거했어요.',
+      );
     },
   });
 

--- a/src/features/problems/components/ProblemActionsMenu.tsx
+++ b/src/features/problems/components/ProblemActionsMenu.tsx
@@ -1,20 +1,23 @@
 import ItemActions from '@/components/ItemActions';
 import { Bookmark, Trash2 } from 'lucide-react';
 import { useProblemActions } from '../hooks/useProblemActions';
+import type { FavoriteToggleSource } from '@/types/problem.type';
 
 type ProblemActionsMenuProps = {
   id: number;
   favorite: boolean;
+  source: FavoriteToggleSource;
   onDelete?: () => void;
 };
 
 export default function ProblemActionsMenu({
   id,
   favorite,
+  source,
   onDelete,
 }: ProblemActionsMenuProps) {
   const { isDeleting, handleDeleteClick, handleFavoriteClick } =
-    useProblemActions(id);
+    useProblemActions(id, source);
 
   const menu = [
     {

--- a/src/features/problems/detail/DetailFooter.tsx
+++ b/src/features/problems/detail/DetailFooter.tsx
@@ -12,7 +12,7 @@ type DetailFooterProps = {
 export default function DetailFooter({ id, isFavorite }: DetailFooterProps) {
   const navigate = useNavigate();
   const { isDeleting, handleDeleteClick, handleFavoriteClick } =
-    useProblemActions(id);
+    useProblemActions(id, 'detail');
 
   const handleDelete = () => {
     handleDeleteClick(() => navigate('/history'));

--- a/src/features/problems/detail/DetailInfo.tsx
+++ b/src/features/problems/detail/DetailInfo.tsx
@@ -30,6 +30,7 @@ export default function DetailInfo({ id, favorite, date }: DetailInfoProps) {
           <ProblemActionsMenu
             id={id}
             favorite={favorite}
+            source='detail'
             onDelete={() => navigate('/history')}
           />
         )}

--- a/src/features/problems/hooks/useProblemActions.ts
+++ b/src/features/problems/hooks/useProblemActions.ts
@@ -1,10 +1,11 @@
 import { useModalStore } from '@/stores/modalStore';
 import { useDeleteProblem } from '../api/delete-problem';
 import { useToggleFavorite } from '../api/toggle-favorite';
+import type { FavoriteToggleSource } from '@/types/problem.type';
 
-export const useProblemActions = (id: number) => {
+export const useProblemActions = (id: number, source: FavoriteToggleSource) => {
   const { mutate: deleteProblem, isPending: isDeleting } = useDeleteProblem();
-  const { toggle } = useToggleFavorite();
+  const { toggle } = useToggleFavorite(source);
   const openModal = useModalStore((state) => state.openModal);
 
   const handleDelete = (onDelete?: () => void) => {

--- a/src/features/problems/list/DesktopItem.tsx
+++ b/src/features/problems/list/DesktopItem.tsx
@@ -1,4 +1,4 @@
-import type { Problem } from '@/types/problem.type';
+import type { FavoriteToggleSource, Problem } from '@/types/problem.type';
 import { Link } from 'react-router-dom';
 import ImageSection from '../components/ImageSection';
 import CardWrapper from '../components/CardWrapper';
@@ -8,9 +8,10 @@ import ProblemActionsMenu from '../components/ProblemActionsMenu';
 
 type DesktopItemProps = {
   item: Problem;
+  source: FavoriteToggleSource;
 };
 
-export default function DesktopItem({ item }: DesktopItemProps) {
+export default function DesktopItem({ item, source }: DesktopItemProps) {
   return (
     <Link to={`/problem/${item.id}`} className='w-full'>
       <CardWrapper>
@@ -38,7 +39,11 @@ export default function DesktopItem({ item }: DesktopItemProps) {
               </p>
             </div>
           </div>
-          <ProblemActionsMenu id={item.id} favorite={item.favorite} />
+          <ProblemActionsMenu
+            id={item.id}
+            favorite={item.favorite}
+            source={source}
+          />
         </div>
       </CardWrapper>
     </Link>

--- a/src/features/problems/list/DesktopView.tsx
+++ b/src/features/problems/list/DesktopView.tsx
@@ -1,15 +1,23 @@
 import type { Problem } from '@/types/problem.type';
 import DesktopItem from './DesktopItem';
+import { useSearchParams } from 'react-router-dom';
 
 type DesktopViewProps = {
   items: Problem[];
 };
 
 export default function DesktopView({ items }: DesktopViewProps) {
+  const [params] = useSearchParams();
+  const favorite = params.get('favorite') === 'true';
+
   return (
     <div className='w-full flex flex-col items-center gap-3 p-2'>
       {items.map((item) => (
-        <DesktopItem key={item.id} item={item} />
+        <DesktopItem
+          key={item.id}
+          item={item}
+          source={favorite ? 'favorite' : 'list'}
+        />
       ))}
     </div>
   );

--- a/src/features/problems/list/MobileView.tsx
+++ b/src/features/problems/list/MobileView.tsx
@@ -1,6 +1,7 @@
 import type { Problem } from '@/types/problem.type';
 import { useToggleFavorite } from '../api/toggle-favorite';
 import MobileItem from './MobileItem';
+import { useSearchParams } from 'react-router-dom';
 
 type MobileViewProps = {
   items: Problem[];
@@ -8,7 +9,9 @@ type MobileViewProps = {
 };
 
 export default function MobileView({ items, variant }: MobileViewProps) {
-  const { toggle } = useToggleFavorite();
+  const [params] = useSearchParams();
+  const favorite = params.get('favorite') === 'true';
+  const { toggle } = useToggleFavorite(favorite ? 'favorite' : 'list');
 
   return (
     <div className='w-full flex flex-col items-center gap-3 p-2'>

--- a/src/pages/ProblemDetailPage.tsx
+++ b/src/pages/ProblemDetailPage.tsx
@@ -12,7 +12,7 @@ export default function ProblemDetailPage() {
   const { _id } = useParams();
   const id = Number(_id);
   const navigate = useNavigate();
-  const { data, isPending, isError, error } = useProblemDetail(_id!);
+  const { data, isPending, isError, error } = useProblemDetail(id);
 
   useEffect(() => {
     if (isError) {

--- a/src/types/problem.type.ts
+++ b/src/types/problem.type.ts
@@ -42,3 +42,9 @@ export type GetFavoriteListResponse = {
     next: string;
   };
 };
+
+export type ToggleFavoriteResponse = {
+  favorited: boolean;
+};
+
+export type FavoriteToggleSource = 'favorite' | 'list' | 'detail';

--- a/src/utils/query-key.ts
+++ b/src/utils/query-key.ts
@@ -5,7 +5,7 @@ type ProblemListParams = {
 export const problemListKey = (params: ProblemListParams) =>
   ['problemList', params] as const;
 
-export const problemDetailKey = (problemId: string) =>
+export const problemDetailKey = (problemId: number) =>
   ['problemDetail', problemId] as const;
 
 export const childInfoKey = () => ['child'] as const;


### PR DESCRIPTION
## PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## PR 상세
### 낙관적 업데이트 범위 변경
- 기존 : 상세/전체 리스트/즐겨찾기 리스트 모두에 낙관적 업데이트 적용
- 변경 후 : 사용자가 보고 있는 화면만 적용(`source` 매개변수로 토글 위치 전달)
  - `detail` : 상세 (즐겨찾기 UI 변경)
  - `list` : 전체 리스트 (즐겨찾기 UI 변경)
  - `favorite` : 즐겨찾기 리스트 (해당 아이템 제거)

### 쿼리 무효화 최소 사용
- 기존 : 즐겨찾기 정보를 가진 모든 쿼리 무효화
- 변경 후
  - 즐겨찾기 리스트 키만 무효화
    (즐겨찾기 리스트에서의 토글은 단순히 불리언 값을 변경하는 것이 아니라 아니라 항목을 추가/제거하는 행위입니다. 클라이언트에서 직접 변경하면 정렬이 어긋나거나 중복/누락이 발생할 수 있어 서버 데이터와 엄격하게 동기화하는 편이 나을 것이라 생각했습니다.)
  - 상세, 전체 리스트는 서버 응답 `favorited`를 기반으로 즐겨찾기 필드를 직접 변경하여 네트워크 요청 최소화 & 개념 정렬이 바뀌는 현상 제거
