### PR TITLE
[AMT-127] 마이페이지 자녀 API 연동 & 로그인 만료 처리

### DIFF
--- a/src/components/layout/RequireAuth.tsx
+++ b/src/components/layout/RequireAuth.tsx
@@ -6,23 +6,18 @@ export default function RequireAuth({
 }: {
   children: React.ReactNode;
 }) {
-  const user = useUserStore((store: userStore) => store.user);
+  const token = sessionStorage.getItem('token');
+  const setUser = useUserStore((store: userStore) => store.setUser);
 
-  if (!user) {
-    if (
-      window.location.pathname !== '/intro' &&
-      window.location.pathname !== '/login' &&
-      window.location.pathname !== '/onboarding'
-    )
+  if (!token) {
+    if (window.location.pathname !== '/intro') {
+      setUser(null);
       return <Navigate to='/intro' replace />;
+    }
   }
 
-  if (user) {
-    if (
-      window.location.pathname === '/onboarding' ||
-      window.location.pathname === '/login' ||
-      window.location.pathname === '/intro'
-    )
+  if (token) {
+    if (window.location.pathname === '/intro')
       return <Navigate to='/' replace />;
   }
 

--- a/src/features/concepts/api/get-concept.ts
+++ b/src/features/concepts/api/get-concept.ts
@@ -4,7 +4,7 @@ import { conceptKey } from '@/utils/query-key';
 import { useQuery } from '@tanstack/react-query';
 
 const getConcept = async (id: number) => {
-  const res = await httpClient.get<Concept>(`/concept?conceptId=${id}`);
+  const res = await httpClient.get<Concept>(`/concepts?conceptId=${id}`);
   return res.data;
 };
 

--- a/src/features/problems/api/get-favorite-list.ts
+++ b/src/features/problems/api/get-favorite-list.ts
@@ -12,7 +12,7 @@ const getFavoriteList = async ({ pageParam }: CursorPaginationParams) => {
   const memberId = useUserStore.getState().user?.memberId;
   if (!memberId) throw new Error('로그인 정보가 없습니다.');
   const res = await httpClient.get<GetFavoriteListResponse>(
-    `/favorite/list?limit=10${pageParam ? `&after_cursor=${pageParam}` : ''}`,
+    `/favorites/list?limit=10${pageParam ? `&after_cursor=${pageParam}` : ''}`,
   );
 
   const updatedData = res.data.data.map((item) => ({

--- a/src/features/problems/api/get-favorite-list.ts
+++ b/src/features/problems/api/get-favorite-list.ts
@@ -6,11 +6,7 @@ import type {
 import { problemListKey } from '@/utils/query-key';
 import { useInfiniteQuery } from '@tanstack/react-query';
 
-import useUserStore from '@/stores/userStore';
-
 const getFavoriteList = async ({ pageParam }: CursorPaginationParams) => {
-  const memberId = useUserStore.getState().user?.memberId;
-  if (!memberId) throw new Error('로그인 정보가 없습니다.');
   const res = await httpClient.get<GetFavoriteListResponse>(
     `/favorites/list?limit=10${pageParam ? `&after_cursor=${pageParam}` : ''}`,
   );

--- a/src/features/problems/api/get-problem-list.ts
+++ b/src/features/problems/api/get-problem-list.ts
@@ -6,10 +6,9 @@ import {
 import { problemListKey } from '@/utils/query-key';
 import { useInfiniteQuery } from '@tanstack/react-query';
 
-
 const getProblemList = async ({ pageParam }: CursorPaginationParams) => {
   const res = await httpClient.get<GetProblemListResponse>(
-    `/problem/list?limit=10${pageParam ? `&after_cursor=${pageParam}` : ''}`,
+    `/problems/list?limit=10${pageParam ? `&after_cursor=${pageParam}` : ''}`,
   );
   return res.data;
 };

--- a/src/features/problems/api/toggle-favorite.ts
+++ b/src/features/problems/api/toggle-favorite.ts
@@ -19,7 +19,7 @@ import { toast } from 'sonner';
 // API 호출 함수
 const toggleFavorite = async (id: number) => {
   const res = await httpClient.post<ToggleFavoriteResponse>(
-    `/favorite?problemId=${id}`,
+    `/favorites?problemId=${id}`,
   );
   return res.data;
 };

--- a/src/features/problems/list/ListSection.tsx
+++ b/src/features/problems/list/ListSection.tsx
@@ -1,11 +1,12 @@
 import { useSearchParams } from 'react-router-dom';
 import Empty from './Empty';
 import { useProblemList } from '../api/get-problem-list';
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
 import { useFavoriteList } from '../api/get-favorite-list';
 import ProblemView from './ProblemView';
 import Skeleton from './Skeleton';
+import { handleApiError } from '@/utils/handle-api-error';
 
 export default function ListSection() {
   const [params] = useSearchParams();
@@ -13,8 +14,15 @@ export default function ListSection() {
   const favorite = params.get('favorite') === 'true';
   const view = (params.get('view') as 'list' | 'grid') ?? 'list';
 
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPending } =
-    favorite ? useFavoriteList() : useProblemList();
+  const {
+    data,
+    isError,
+    error,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isPending,
+  } = favorite ? useFavoriteList() : useProblemList();
 
   const problems = data?.pages.flatMap((page) => page.data) ?? [];
   const targetRef = useRef<HTMLDivElement | null>(null);
@@ -26,7 +34,14 @@ export default function ListSection() {
     rootMargin: '200px 0px',
   });
 
+  useEffect(() => {
+    if (isError) {
+      handleApiError(error);
+    }
+  }, [isError, error]);
+
   if (isPending) return <Skeleton mobileVariant={view} />;
+
   if (problems.length === 0) {
     return (
       <Empty

--- a/src/features/users/api/get-child-info.ts
+++ b/src/features/users/api/get-child-info.ts
@@ -4,7 +4,7 @@ import type { Child } from '@/types/user.type';
 import { childInfoKey } from '@/utils/query-key';
 
 const getChildInfo = async () => {
-  const res = await httpClient.get<Child>('api/v2/members/me/profile');
+  const res = await httpClient.get<Child>('/members/me/profile');
   return res.data;
 };
 

--- a/src/features/users/api/get-child-info.ts
+++ b/src/features/users/api/get-child-info.ts
@@ -1,10 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
 import { httpClient } from '@/lib/api-client';
-import type { Child } from '@/types/user.type';
+import type { Child, MemberResponseType } from '@/types/user.type';
 import { childInfoKey } from '@/utils/query-key';
 
 const getChildInfo = async () => {
-  const res = await httpClient.get<Child>('/members/me/profile');
+  const res = await httpClient.get<MemberResponseType<Child>>(
+    '/members/child/profile',
+  );
   return res.data;
 };
 

--- a/src/features/users/api/get-kakao-member-info.ts
+++ b/src/features/users/api/get-kakao-member-info.ts
@@ -29,7 +29,7 @@ interface getKakaoMemberInfoType {
 }
 
 const getKakaoMemberInfo = async (code: string) => {
-  const res = await httpClient.get(`/api/v2/oauth`, { params: { code: code } });
+  const res = await httpClient.get(`/oauth`, { params: { code: code } });
   return res.data;
 };
 

--- a/src/features/users/api/get-kakao-member-info.ts
+++ b/src/features/users/api/get-kakao-member-info.ts
@@ -41,10 +41,9 @@ export const useKakaoMemberInfo: getKakaoMemberInfoType = (
     mutationFn: (code: string) => getKakaoMemberInfo(code),
     onSuccess: (res) => {
       const token = res.result.accessToken;
-      const memberId = res.result.memberId;
       if (token) {
         sessionStorage.setItem('token', token);
-        setUser({ accessToken: token, memberId: memberId });
+        setUser({ accessToken: token });
         toast.success(res.message || '로그인 성공!');
         navigate('/');
       }

--- a/src/features/users/api/update-child-info.ts
+++ b/src/features/users/api/update-child-info.ts
@@ -2,12 +2,12 @@ import { useMutation } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { httpClient } from '@/lib/api-client';
 import { queryClient } from '@/lib/react-query';
-import type { Child, UpdateChildRequest } from '@/types/user.type';
+import type { Child } from '@/types/user.type';
 import { handleApiError } from '@/utils/handle-api-error';
 import { childInfoKey } from '@/utils/query-key';
 
-const updateChildInfo = async (data: UpdateChildRequest) => {
-  const res = await httpClient.put(`/members/me/profile`, data);
+const updateChildInfo = async (data: Child) => {
+  const res = await httpClient.patch(`/members/child/profile`, data);
   return res.data;
 };
 
@@ -15,7 +15,7 @@ export const useUpdateChildInfo = () => {
   const queryKey = childInfoKey();
 
   return useMutation({
-    mutationFn: (data: UpdateChildRequest) => updateChildInfo(data),
+    mutationFn: (data: Child) => updateChildInfo(data),
 
     onMutate: async (data) => {
       await queryClient.cancelQueries({ queryKey });
@@ -27,8 +27,10 @@ export const useUpdateChildInfo = () => {
 
         return {
           ...old,
-          name: data.name,
-          grade: data.grade,
+          result: {
+            childName: data.childName,
+            childGrade: data.childGrade,
+          },
         };
       });
 

--- a/src/features/users/api/update-child-info.ts
+++ b/src/features/users/api/update-child-info.ts
@@ -7,7 +7,7 @@ import { handleApiError } from '@/utils/handle-api-error';
 import { childInfoKey } from '@/utils/query-key';
 
 const updateChildInfo = async (data: UpdateChildRequest) => {
-  const res = await httpClient.put(`api/v2/members/me/profile`, data);
+  const res = await httpClient.put(`/members/me/profile`, data);
   return res.data;
 };
 

--- a/src/features/users/my-page/ChildCard.tsx
+++ b/src/features/users/my-page/ChildCard.tsx
@@ -3,7 +3,7 @@ import Profile from './Profile';
 import { SquarePen } from 'lucide-react';
 import type { Concept } from '@/types/concept.type';
 import { useModalStore } from '@/stores/modalStore';
-import type { UpdateChildRequest } from '@/types/user.type';
+import type { Child } from '@/types/user.type';
 import { getGradeLabel } from '@/utils/constants/grades';
 import { useUpdateChildInfo } from '../api/update-child-info';
 
@@ -13,12 +13,10 @@ type ChildCardProps = {
   concepts: Omit<Concept, 'description'>[];
 };
 
-
-
 export default function ChildCard({ name, grade, concepts }: ChildCardProps) {
   const { mutate: updateChild, isPending: isUpdating } = useUpdateChildInfo();
   const openModal = useModalStore((state) => state.openModal);
-  const handleConfirm = (data: UpdateChildRequest) => {
+  const handleConfirm = (data: Child) => {
     updateChild(data);
   };
 
@@ -26,7 +24,7 @@ export default function ChildCard({ name, grade, concepts }: ChildCardProps) {
     <div className='relative max-w-[500px] w-full h-full flex flex-col items-center gap-3 bg-white dark:bg-gray6 rounded-[16px] shadow-[var(--shadow)] dark:shadow-[var(--shadow-dark)] p-4'>
       <Profile size='small' />
       <div className='flex flex-col items-center gap-1'>
-        <p className='font-semibold'>{name}</p>
+        <p className='font-semibold'>{name || '아직 등록된 자녀가 없어요.'}</p>
         <p className='body-sm text-gray6 dark:text-gray3'>
           {getGradeLabel(grade)}
         </p>

--- a/src/features/users/my-page/ChildUpdateModal.tsx
+++ b/src/features/users/my-page/ChildUpdateModal.tsx
@@ -16,7 +16,7 @@ import {
   SelectItem,
 } from '@/components/ui/select';
 import type { BaseModalProps } from '@/types/modal.type';
-import type { UpdateChildRequest } from '@/types/user.type';
+import type { Child } from '@/types/user.type';
 import { GRADE_OPTIONS } from '@/utils/constants/grades';
 import { Controller, useForm } from 'react-hook-form';
 
@@ -24,12 +24,12 @@ interface ChildUpdateModal extends BaseModalProps {
   name: string;
   grade: number;
   isUpdating: boolean;
-  onConfirm: (data: UpdateChildRequest) => void;
+  onConfirm: (data: Child) => void;
 }
 
 type ChildUpdateForm = {
-  name: string;
-  grade: string;
+  childName: string;
+  childGrade: string;
 };
 
 export default function ChildUpdateModal({
@@ -45,19 +45,19 @@ export default function ChildUpdateModal({
     control,
     formState: { isValid },
   } = useForm<ChildUpdateForm>({
-    defaultValues: { name, grade: String(grade) },
+    defaultValues: { childName: name, childGrade: String(grade) },
     mode: 'onChange',
   });
 
   const onSubmit = (data: ChildUpdateForm) => {
-    if (name === data.name && grade === Number(data.grade)) {
+    if (name === data.childName && grade === Number(data.childGrade)) {
       onClose();
       return;
     }
 
     onConfirm({
-      name: data.name,
-      grade: Number(data.grade),
+      childName: data.childName,
+      childGrade: Number(data.childGrade),
     });
     onClose();
   };
@@ -74,12 +74,12 @@ export default function ChildUpdateModal({
         >
           <section className='w-3/4 flex flex-col items-center gap-3'>
             <Input
-              {...register('name', { required: true })}
+              {...register('childName', { required: true })}
               placeholder='자녀의 이름을 입력해주세요.'
               className='body-sm'
             />
             <Controller
-              name='grade'
+              name='childGrade'
               control={control}
               rules={{ required: true }}
               render={({ field }) => (

--- a/src/features/users/my-page/ChildrenListSection.tsx
+++ b/src/features/users/my-page/ChildrenListSection.tsx
@@ -1,7 +1,6 @@
 import ChildCard from './ChildCard';
 import { useChildInfo } from '../api/get-child-info';
 import { handleApiError } from '@/utils/handle-api-error';
-import axios from 'axios';
 import DataLoading from '@/components/DataLoading';
 import { useNavigate } from 'react-router-dom';
 import { useEffect } from 'react';
@@ -18,16 +17,6 @@ export default function ChildrenListSection() {
   useEffect(() => {
     if (isError) {
       handleApiError(error);
-      const status = axios.isAxiosError(error) ? error.response?.status : null;
-
-      if (status === 403 || status === 404)
-        navigate('/not-found', {
-          state: { from: 'api-error' },
-        });
-      else
-        navigate('/error', {
-          state: { from: 'api-error' },
-        });
     }
   }, [isError, error, navigate]);
 

--- a/src/features/users/my-page/ChildrenListSection.tsx
+++ b/src/features/users/my-page/ChildrenListSection.tsx
@@ -12,7 +12,7 @@ const concepts = [
 ];
 
 export default function ChildrenListSection() {
-  const { data, isPending, isError, error } = useChildInfo(8);
+  const { data, isPending, isError, error } = useChildInfo();
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -34,6 +34,7 @@ export default function ChildrenListSection() {
   if (isPending) {
     return <DataLoading description='아이 정보를 불러오고 있어요...' />;
   }
+
   if (isError) return null;
 
   return (
@@ -45,7 +46,11 @@ export default function ChildrenListSection() {
           태그를 눌러 개념 설명을 확인해보세요.
         </p>
       </div>
-      <ChildCard name={data.name} grade={data.grade} concepts={concepts} />
+      <ChildCard
+        name={data.result.childName}
+        grade={data.result.childGrade}
+        concepts={concepts}
+      />
     </section>
   );
 }

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -40,15 +40,9 @@ httpClient.interceptors.response.use(
     return response;
   },
   (error) => {
-    if (error.response?.status === 401) {
-      if (window.location.pathname !== '/login') {
-        window.location.href = '/login';
-      }
-    }
-
     const message = error.response?.data?.message || error.message;
     console.error(message);
 
     return Promise.reject(error);
-  }
+  },
 );

--- a/src/pages/KakaoAuthPage.tsx
+++ b/src/pages/KakaoAuthPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import Loading from '@/components/Loading';
 import useUserStore from '@/stores/userStore';
@@ -9,8 +9,6 @@ export default function KakaoAuthPage() {
   const navigate = useNavigate();
   const setUser = useUserStore((state) => state.setUser);
   const { mutate: kakaoLogin } = useKakaoMemberInfo(setUser, navigate);
-  
-  const requestedRef = useRef(false);
 
   useEffect(() => {
     const code = searchParams.get('code');
@@ -18,12 +16,9 @@ export default function KakaoAuthPage() {
       navigate('/intro');
       return;
     }
-    if (requestedRef.current) return;
-    requestedRef.current = true;
+
     kakaoLogin(code);
-    
-    navigate('/oauth/kakao', { replace: true });
-  }, [searchParams, kakaoLogin, navigate]);
+  }, [searchParams]);
 
   return <Loading />;
 }

--- a/src/stores/userStore.ts
+++ b/src/stores/userStore.ts
@@ -3,12 +3,11 @@ import { createJSONStorage, persist } from 'zustand/middleware';
 
 export type user = {
   accessToken: string;
-  memberId?: string;
 };
 
 export type userStore = {
   user: user | null;
-  setUser: (user: user) => void;
+  setUser: (user: user | null) => void;
 };
 
 const useUserStore = create<userStore>()(

--- a/src/types/user.type.ts
+++ b/src/types/user.type.ts
@@ -5,11 +5,22 @@ export type userData = {
   childGrade?: number; // 선택적 필드
 };
 
+// members 도메인 공통 응답 타입 정의
+export type MemberResponseType<T> = {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  result: T;
+};
+
+export type User = {
+  nickname: string;
+  email: string;
+};
+
 export type Child = {
-  id: number;
-  name: string;
-  username: string;
-  grade: number;
+  childName: string;
+  childGrade: number;
 };
 
 export type UpdateChildRequest = {

--- a/src/types/user.type.ts
+++ b/src/types/user.type.ts
@@ -22,8 +22,3 @@ export type Child = {
   childName: string;
   childGrade: number;
 };
-
-export type UpdateChildRequest = {
-  name: string;
-  grade: number;
-};

--- a/src/utils/constants/grades.ts
+++ b/src/utils/constants/grades.ts
@@ -32,5 +32,7 @@ export const GRADE_OPTIONS: Grades[] = [
 export const getGradeLabel = (grade: number) => {
   const result = GRADE_OPTIONS.find((option) => option.value === grade);
 
-  return result ? result.label : '학년 정보 없음';
+  return result
+    ? result.label
+    : '오른쪽 위 수정 버튼을 눌러 자녀를 등록할 수 있어요.';
 };

--- a/src/utils/handle-api-error.ts
+++ b/src/utils/handle-api-error.ts
@@ -14,9 +14,8 @@ export function handleApiError(error: unknown) {
     toast.error(message || '잘못된 요청입니다.');
   } else if (status === 401) {
     toast.error('로그인이 필요합니다.');
-    setTimeout(() => {
-      window.location.href = '/intro';
-    }, 1500);
+    sessionStorage.removeItem('token');
+    setTimeout(() => (window.location.href = '/intro'), 1000);
   } else if (status === 404) {
     toast.error(message || '데이터를 찾을 수 없습니다.');
   } else if (status && status >= 500) {
@@ -26,6 +25,7 @@ export function handleApiError(error: unknown) {
   }
 }
 
+// 일반 로그인 제거 시 함께 삭제
 export function handleLoginError(error: unknown) {
   if (!axios.isAxiosError(error)) {
     toast.error('알 수 없는 오류가 발생했어요.');


### PR DESCRIPTION
## PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## PR 상세
### 1. API 엔드포인트 변경에 따른 코드 수정
- API 호출부
  - 엔드포인트 도메인: 단수 → 복수 변경
  - `/api/v2` 경로는 환경변수로 분리
- `userStore`
  - `memberId` 필드 제거

### 2. 마이페이지 자녀 API 연동
- 공통 응답 타입 정의
  - `MemberResponseType` 추가 (`types/user.type.ts`)
  - `/members` 도메인의 응답 형식이 동일하여 공통 타입으로 분리
- API 연동
  - 자녀 정보 조회: `features/users/api/get-child-info.ts`
  - 자녀 정보 수정: `features/users/api/update-child-info.ts`
    → ***온보딩 단계에서 자녀 정보를 추가할 때 `useUpdateChildInfo` 사용***

### 3. 로그인 만료 처리 개선
- `handle-api-error.ts`
  - 세션 만료 시: sessionStorage 토큰 제거 후 `/intro`로 리다이렉트
  - 토스트 메시지 표시를 위해 axios 응답 인터셉터에서의 처리 로직은 제거
- `RequireAuth.tsx`
  - 로그인 여부 확인 방식 변경
    - 기존: `userStore.user` 존재 여부
    - 변경 후: sessionStorage 내 토큰 여부 확인, 없으면 user를 null로 설정
  - 인증 불필요 페이지
    - 기존: `/intro`, `/login`, `/onboarding`
    - 변경 후: `/intro`
  